### PR TITLE
Fixups from after splitting Abscissa into its own project

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,15 +7,15 @@ description = """
 version     = "0.0.0" # Also update html_root_url in lib.rs when bumping this
 license     = "Apache-2.0"
 authors     = ["Tony Arcieri <tony@iqlusion.io>", "Murarth <murarth@gmail.com>", "David Tolnay <dtolnay@gmail.com>"]
-homepage    = "https://github.com/iqlusioninc/crates/"
-repository  = "https://github.com/iqlusioninc/crates/tree/master/abscissa"
+homepage    = "https://github.com/iqlusioninc/abscissa/"
+repository  = "https://github.com/iqlusioninc/abscissa/tree/master/"
 readme      = "README.md"
 categories  = ["command-line-interface", "rust-patterns", "web-programming"]
 keywords    = ["application", "container", "microservices", "framework", "service"]
 
 [badges]
-circle-ci = { repository = "iqlusioninc/crates" }
-appveyor  = { repository = "iqlusioninc/crates" }
+circle-ci = { repository = "iqlusioninc/abscissa" }
+appveyor  = { repository = "tony-iqlusion/abscissa" }
 
 [dependencies]
 canonical-path = "0.1"

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# ![Abscissa](https://www.iqlusion.io/img/github/iqlusioninc/crates/abscissa/abscissa.svg)
+# ![Abscissa](https://www.iqlusion.io/img/github/iqlusioninc/abscissa/abscissa.svg)
 
 [![Crate][crate-image]][crate-link]
 [![Docs][docs-image]][docs-link]
@@ -11,11 +11,11 @@
 [docs-image]: https://docs.rs/abscissa/badge.svg
 [docs-link]: https://docs.rs/abscissa/
 [license-image]: https://img.shields.io/badge/license-Apache2.0-blue.svg
-[license-link]: https://github.com/iqlusioninc/crates/blob/master/LICENSE
-[build-image]: https://circleci.com/gh/iqlusioninc/crates.svg?style=shield
-[build-link]: https://circleci.com/gh/iqlusioninc/crates
-[appveyor-image]: https://ci.appveyor.com/api/projects/status/1ua33q2njho24e9h?svg=true
-[appveyor-link]: https://ci.appveyor.com/project/tony-iqlusion/crates
+[license-link]: https://github.com/iqlusioninc/abscissa/blob/master/LICENSE
+[build-image]: https://circleci.com/gh/iqlusioninc/abscissa.svg?style=shield
+[build-link]: https://circleci.com/gh/iqlusioninc/abscissa
+[appveyor-image]: https://ci.appveyor.com/api/projects/status/9bgh8je3rsmbyo0y?svg=true
+[appveyor-link]: https://ci.appveyor.com/project/tony-iqlusion/abscissa
 
 Abscissa is a microframework for building Rust applications (either CLI tools
 or network/web services), aiming to provide a large number of features with a
@@ -51,8 +51,11 @@ or network/web services), aiming to provide a large number of features with a
 
 ### Q1: Why is it called "abscissa"?
 
-**A1:** 
+**A1:** An abscissa represents the elevation of a point above the y-axis.
+In that regard, "Abscissa" can be thought of as a pun about getting off
+the ground, or elevating your project.
 
+The word "abscissa" is also the key to the Kryptos K2 panel.
 
 ## License
 
@@ -63,10 +66,10 @@ Parts of this code were taken from the following projects, which have agreed
 to license their code under the Apache License (Version 2.0):
 
 * [Cargo](https://github.com/rust-lang/cargo)
+* [failure](https://github.com/withoutboats/failure)
 * [gumdrop]
 * [isatty](https://github.com/dtolnay/isatty)
 
-See [LICENSE] file in the `iqlusioninc/crates` toplevel directory for more
-information.
+See [LICENSE] file in the toplevel directory for more information.
 
-[LICENSE]: https://github.com/iqlusioninc/crates/blob/master/LICENSE
+[LICENSE]: https://github.com/iqlusioninc/abscissa/blob/master/LICENSE

--- a/abscissa_derive/Cargo.toml
+++ b/abscissa_derive/Cargo.toml
@@ -4,15 +4,15 @@ description = "Custom derive support for the abscissa application microframework
 version     = "0.0.0" # Also update html_root_url in lib.rs when bumping this
 license     = "Apache-2.0"
 authors     = ["Tony Arcieri <tony@iqlusion.io>", "Murarth <murarth@gmail.com>", "Without Boats <boats@mozilla.com>"]
-homepage    = "https://github.com/iqlusioninc/crates/abscissa"
-repository  = "https://github.com/iqlusioninc/crates/tree/master/abscissa_derive"
+homepage    = "https://github.com/iqlusioninc/abscissa"
+repository  = "https://github.com/iqlusioninc/abscissa/tree/master/abscissa_derive"
 readme      = "README.md"
 categories  = ["command-line-interface"]
 keywords    = ["args", "command-line", "flag", "getopts", "option"]
 
 [badges]
-circle-ci = { repository = "iqlusioninc/crates" }
-appveyor  = { repository = "iqlusioninc/crates" }
+circle-ci = { repository = "iqlusioninc/abscissa" }
+appveyor  = { repository = "tony-iqlusion/abscissa" }
 
 [lib]
 name = "abscissa_derive"

--- a/abscissa_derive/README.md
+++ b/abscissa_derive/README.md
@@ -1,4 +1,4 @@
-![Abscissa](https://www.iqlusion.io/img/github/iqlusioninc/crates/abscissa/abscissa.svg)
+![Abscissa](https://www.iqlusion.io/img/github/iqlusioninc/abscissa/abscissa.svg)
 
 # abscissa_derive: custom derive macros
 
@@ -13,11 +13,11 @@
 [docs-image]: https://docs.rs/abscissa_derive/badge.svg
 [docs-link]: https://docs.rs/abscissa_derive/
 [license-image]: https://img.shields.io/badge/license-Apache2.0-blue.svg
-[license-link]: https://github.com/iqlusioninc/crates/blob/master/LICENSE
-[build-image]: https://circleci.com/gh/iqlusioninc/crates.svg?style=shield
-[build-link]: https://circleci.com/gh/iqlusioninc/crates
-[appveyor-image]: https://ci.appveyor.com/api/projects/status/1ua33q2njho24e9h?svg=true
-[appveyor-link]: https://ci.appveyor.com/project/tony-iqlusion/crates
+[license-link]: https://github.com/iqlusioninc/abscissa/blob/master/LICENSE
+[build-image]: https://circleci.com/gh/iqlusioninc/abscissa.svg?style=shield
+[build-link]: https://circleci.com/gh/iqlusioninc/abscissa
+[appveyor-image]: https://ci.appveyor.com/api/projects/status/9bgh8je3rsmbyo0y?svg=true
+[appveyor-link]: https://ci.appveyor.com/project/tony-iqlusion/abscissa
 
 This crate provides the custom derive implementations used by the
 [abscissa] command-line app microframework.
@@ -27,7 +27,7 @@ framework itself in a single crate. This ensures that proc macro upgrades
 can be performed atomically (i.e. this won't ever depend on 3 versions of
 `syn`), and minimizes the amount of code running as part of the build process.
 
-[abscissa]: https://github.com/iqlusioninc/crates/tree/master/abscissa
+[abscissa]: https://github.com/iqlusioninc/abscissa/tree/master/
 
 ## Features
 
@@ -46,7 +46,6 @@ Apache License (Version 2.0). It is a fork of the [failure_derive]
 and [gumdrop_derive] crates, which also also distributed under the
 terms of the Apache License (Version 2.0).
 
-See [LICENSE] file in the `iqlusioninc/crates` toplevel directory for more
-information.
+See [LICENSE] file in the toplevel directory for more information.
 
-[LICENSE]: https://github.com/iqlusioninc/crates/blob/master/LICENSE
+[LICENSE]: https://github.com/iqlusioninc/abscissa/blob/master/LICENSE

--- a/abscissa_derive/src/lib.rs
+++ b/abscissa_derive/src/lib.rs
@@ -21,7 +21,7 @@
 )]
 #![recursion_limit = "1024"]
 #![doc(
-    html_logo_url = "https://www.iqlusion.io/img/github/iqlusioninc/crates/abscissa/abscissa-sq.svg",
+    html_logo_url = "https://www.iqlusion.io/img/github/iqlusioninc/abscissa/abscissa-sq.svg",
     html_root_url = "https://docs.rs/abscissa_derive/0.0.0"
 )]
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -62,9 +62,8 @@
     unused_import_braces,
     unused_qualifications
 )]
-#![doc(html_root_url = "https://docs.rs/abscissa/0.0.0")]
 #![doc(
-    html_logo_url = "https://www.iqlusion.io/img/github/iqlusioninc/crates/abscissa/abscissa-sq.svg",
+    html_logo_url = "https://www.iqlusion.io/img/github/iqlusioninc/abscissa/abscissa-sq.svg",
     html_root_url = "https://docs.rs/abscissa/0.0.0"
 )]
 


### PR DESCRIPTION
Fixes lingering references to `iqlusion/crates`