### PR TITLE
util.rs: Export the "chrono" crate under "util::time"

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ keywords    = ["application", "container", "microservices", "framework", "servic
 [dependencies]
 abscissa_derive = { version = "0", path = "abscissa_derive" }
 canonical-path = "0.1"
+chrono = { version = "0.4", optional = true, features = ["serde"] }
 clear_on_drop = "0.2"
 failure = { version = "0.1", default-features = false, features = ["std"] }
 lazy_static = "1"
@@ -45,7 +46,7 @@ config = [
     "status",
     "toml"
 ]
-default = ["application"]
+default = ["application", "chrono"]
 errors = []
 logging = [
     "errors",

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,6 +1,8 @@
 //! Miscellaneous utilities
 
 extern crate canonical_path;
+#[cfg(feature = "chrono")]
+pub extern crate chrono as time;
 extern crate clear_on_drop;
 #[cfg(feature = "application")]
 extern crate semver;


### PR DESCRIPTION
We already pull in Chrono as a dependency via the `simplelog` crate (when logging is enabled). Might as well export it through `util` in case apps want to use it for their own purposes.