### PR TITLE
v0.0.2

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,16 @@
+## [0.0.2] (2018-08-28)
+
+[0.0.2]: https://github.com/iqlusioninc/abscissa/compare/v0.0.1...v0.0.2
+
+* [#11](https://github.com/iqlusioninc/abscissa/pull/11)
+  Use the `failure_derive` crate.
+
+* [#10](https://github.com/iqlusioninc/abscissa/pull/10)
+  Use the `isatty` crate.
+
+* [#8](https://github.com/iqlusioninc/abscissa/pull/8)
+  **util.rs**: Export the `chrono` crate under `util::time`.
+
 ## 0.0.1 (2018-08-25)
 
 * Initial release

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1,6 +1,6 @@
 [[package]]
 name = "abscissa"
-version = "0.0.1"
+version = "0.0.2"
 dependencies = [
  "abscissa_derive 0.0.1",
  "assert_matches 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,9 +4,9 @@ description = """
               Application microframework with support for command-line option parsing,
               configuration, error handling, logging, and shell interactions
               """
-version     = "0.0.1" # Also update html_root_url in lib.rs when bumping this
+version     = "0.0.2" # Also update html_root_url in lib.rs when bumping this
 license     = "Apache-2.0"
-authors     = ["Tony Arcieri <tony@iqlusion.io>", "Murarth <murarth@gmail.com>"]
+authors     = ["Tony Arcieri <tony@iqlusion.io>"]
 homepage    = "https://github.com/iqlusioninc/abscissa/"
 repository  = "https://github.com/iqlusioninc/abscissa/tree/master/"
 readme      = "README.md"

--- a/abscissa_derive/src/options/mod.rs
+++ b/abscissa_derive/src/options/mod.rs
@@ -54,6 +54,8 @@
 //! `gumdrop_derive` crate:
 //!
 //! <https://github.com/murarth/gumdrop>
+//!
+//! Author: Murarth <murarth@gmail.com>
 
 use std::iter::repeat;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -64,7 +64,7 @@
 )]
 #![doc(
     html_logo_url = "https://www.iqlusion.io/img/github/iqlusioninc/abscissa/abscissa-sq.svg",
-    html_root_url = "https://docs.rs/abscissa/0.0.1"
+    html_root_url = "https://docs.rs/abscissa/0.0.2"
 )]
 
 #[allow(unknown_lints, unused_imports, useless_attribute)]

--- a/src/options/mod.rs
+++ b/src/options/mod.rs
@@ -171,7 +171,10 @@
 //! # Notice
 //!
 //! This portion of `abscissa` functionality is a fork of the `gumdrop` crate:
+//!
 //! <https://github.com/murarth/gumdrop>
+//!
+//! Author: Murarth <murarth@gmail.com>
 
 #[doc(hidden)]
 pub use abscissa_derive::*;


### PR DESCRIPTION
[Diff from 0.0.1](https://github.com/iqlusioninc/abscissa/compare/v0.0.1...v0.0.2)

* #11: Use the `failure_derive` crate.
* #10: Use the `isatty` crate.
* #8: **util.rs**: Export the `chrono` crate under `util::time`.