### PR TITLE
make error module public

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -103,7 +103,7 @@ mod command;
 #[cfg(feature = "config")]
 pub mod config;
 #[cfg(feature = "errors")]
-mod error;
+pub mod error;
 #[cfg(feature = "logging")]
 pub mod logging;
 #[cfg(feature = "options")]


### PR DESCRIPTION
Make error module public to fix following error when using the `err!` macro:

```
error[E0603]: module `error` is private
  --> src/error.rs:17:9
   |
17 |         err!(CanisterErrorKind::IoError, err)
   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```