### PR TITLE
Application: add boot() method to trait

### DIFF
--- a/src/application/mod.rs
+++ b/src/application/mod.rs
@@ -29,6 +29,9 @@ pub trait Application: Send + Sized + Sync {
     /// Configuration type used by this application
     type Config: GlobalConfig;
 
+    /// Boot the application
+    fn boot() -> !;
+
     /// Get a read lock on the application's global configuration
     fn config(&self) -> ConfigReader<Self::Config> {
         Self::Config::get_global()


### PR DESCRIPTION
This allows `main.rs` for an Abscissa application to look like:

```
extern crate myapp;
use myapp::{Application, MyApp};

fn main() {
    MyApp::boot();
}
```