### PR TITLE
abscissa_generator: Generate new apps with "abscissa new"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ matrix:
         - cargo clippy
     - name: build
       script:
-        - cargo build --no-default-features
+        - cargo build --no-default-features --lib
         - cargo build --release --all --all-features
     - name: test
       script:
@@ -33,3 +33,11 @@ matrix:
     - name: doc
       script:
         - cargo doc --all-features
+    - name: abscissa new (fmt + test + run + clippy)
+      script:
+        - cargo run --release -- new /tmp/example_app --patch-crates-io="abscissa = { path = \"$PWD\" }"
+        - cd /tmp/example_app
+        - cargo fmt -- --check
+        - cargo test --release
+        - cargo run -- --version
+        - cargo clippy

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5,16 +5,17 @@ name = "abscissa"
 version = "0.0.6"
 dependencies = [
  "abscissa_derive 0.0.2",
+ "abscissa_generator 0.0.0",
  "atty 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "canonical-path 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "gumdrop 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gumdrop_derive 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)",
  "simplelog 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "term 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -29,6 +30,27 @@ dependencies = [
  "quote 0.6.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 0.15.29 (registry+https://github.com/rust-lang/crates.io-index)",
  "synstructure 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "abscissa_generator"
+version = "0.0.0"
+dependencies = [
+ "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "handlebars 2.0.0-beta.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hashbrown 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "aho-corasick"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "memchr 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -69,6 +91,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-buffer"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "block-padding 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byte-tools 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "generic-array 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "block-padding"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "byte-tools 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "byte-tools"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "byteorder"
 version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -100,6 +146,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "digest"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "generic-array 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "failure"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -117,6 +171,19 @@ dependencies = [
  "quote 0.6.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 0.15.29 (registry+https://github.com/rust-lang/crates.io-index)",
  "synstructure 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "fake-simd"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "generic-array"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "typenum 1.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -138,6 +205,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "handlebars"
+version = "2.0.0-beta.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "hashbrown 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pest 2.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pest_derive 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quick-error 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 1.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
+ "walkdir 2.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "serde 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "heck"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "unicode-segmentation 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "itoa"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "lazy_static"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -154,6 +259,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cfg-if 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "maplit"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "memchr"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "num-integer"
@@ -174,12 +289,61 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "opaque-debug"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "pest"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "ucd-trie 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "pest_derive"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "pest 2.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pest_generator 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "pest_generator"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "pest 2.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pest_meta 2.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.4.27 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.29 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "pest_meta"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "maplit 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pest 2.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sha-1 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "0.4.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "quick-error"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "quote"
@@ -203,9 +367,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex"
+version = "1.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "aho-corasick 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memchr 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex-syntax 0.6.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "thread_local 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "utf8-ranges 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "ucd-util 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "rustc-demangle"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "ryu"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "same-file"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "winapi-util 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "semver"
@@ -213,6 +410,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "semver-parser 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -224,6 +422,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "serde"
 version = "1.0.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "serde_derive 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "serde_derive"
@@ -233,6 +434,27 @@ dependencies = [
  "proc-macro2 0.4.27 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 0.15.29 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.39"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "itoa 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ryu 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "sha-1"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "block-buffer 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "digest 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fake-simd 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "opaque-debug 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -297,6 +519,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread_local"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "time"
 version = "0.1.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -315,9 +545,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "typenum"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "ucd-trie"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "ucd-util"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "unicode-xid"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "utf8-ranges"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "walkdir"
+version = "2.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "same-file 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi-util 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "winapi"
@@ -332,6 +597,14 @@ dependencies = [
 name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"
@@ -357,45 +630,78 @@ dependencies = [
 ]
 
 [metadata]
+"checksum aho-corasick 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)" = "e6f484ae0c99fec2e858eb6134949117399f222608d84cadb3f58c1f97c2364c"
 "checksum atty 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "9a7d5b8723950951411ee34d271d99dddcc2035a16ab25310ea2c8cfd4369652"
 "checksum autocfg 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a6d640bee2da49f60a4068a7fae53acde8982514ab7bae8b8cea9e88cbcfd799"
 "checksum backtrace 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)" = "cd5a90e2b463010cd0e0ce9a11d4a9d5d58d9f41d4a6ba3dcaf9e68b466e88b4"
 "checksum backtrace-sys 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)" = "797c830ac25ccc92a7f8a7b9862bde440715531514594a6154e3d4a54dd769b6"
+"checksum block-buffer 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)" = "c0940dc441f31689269e10ac70eb1002a3a1d3ad1390e030043662eb7fe4688b"
+"checksum block-padding 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "6d4dc3af3ee2e12f3e5d224e5e1e3d73668abbeb69e566d361f7d5563a4fdf09"
+"checksum byte-tools 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "e3b5ca7a04898ad4bcd41c90c5285445ff5b791899bb1b0abdd2a2aa791211d7"
 "checksum byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a019b10a2a7cdeb292db131fc8113e57ea2a908f6e7894b0c3c671893b65dbeb"
 "checksum canonical-path 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "9aa83b9f518bd3943b6757de8489c7756566df78026771955b90ecb87295a5dc"
 "checksum cc 1.0.32 (registry+https://github.com/rust-lang/crates.io-index)" = "ad0daef304fa0b4238f5f7ed7178774b43b06f6a9b6509f6642bef4ff1f7b9b2"
 "checksum cfg-if 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "11d43355396e872eefb45ce6342e4374ed7bc2b3a502d1b28e36d6e23c05d1f4"
 "checksum chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "45912881121cb26fad7c38c17ba7daa18764771836b34fab7d3fbd93ed633878"
+"checksum digest 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "05f47366984d3ad862010e22c7ce81a7dbcaebbdfb37241a620f8b6596ee135c"
 "checksum failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "795bd83d3abeb9220f257e597aa0080a508b27533824adf336529648f6abf7e2"
 "checksum failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "ea1063915fd7ef4309e222a5a07cf9c319fb9c7836b1f89b85458672dbb127e1"
+"checksum fake-simd 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e88a8acf291dafb59c2d96e8f59828f3838bb1a70398823ade51a84de6a6deed"
+"checksum generic-array 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3c0f28c2f5bfb5960175af447a2da7c18900693738343dc896ffbcabd9839592"
 "checksum gumdrop 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "395c7c79599167d04e7349ee60cc6cb14a28dfebaf922b4dc41603a7b18c3b28"
 "checksum gumdrop_derive 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "04c43663fd6604d9065f5cd26ae7a0301491fd941ad29b0a01665a6be3a1ddbd"
+"checksum handlebars 2.0.0-beta.2 (registry+https://github.com/rust-lang/crates.io-index)" = "cfcc4c7d5274ebfa5c5c1d9464b5bfa7a15c784a9f016d7c43b8aa71ad2631d2"
+"checksum hashbrown 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "61e4900fa4e80b3d15c78a08ec8a08433246063fa7577e7b2c6426b3b21b1f79"
+"checksum heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "20564e78d53d2bb135c343b3f47714a56af2061f1c928fdb541dc7b9fdd94205"
+"checksum itoa 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "501266b7edd0174f8530248f87f99c88fbe60ca4ef3dd486835b8d8d53136f7f"
 "checksum lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bc5729f27f159ddd61f4df6228e827e86643d4d3e7c32183cb30a1c08f604a14"
 "checksum libc 0.2.50 (registry+https://github.com/rust-lang/crates.io-index)" = "aab692d7759f5cd8c859e169db98ae5b52c924add2af5fbbca11d12fefb567c1"
 "checksum log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c84ec4b527950aa83a329754b01dbe3f58361d1c5efacd1f6d68c494d08a17c6"
+"checksum maplit 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "08cbb6b4fef96b6d77bfc40ec491b1690c779e77b05cd9f07f787ed376fd4c43"
+"checksum memchr 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2efc7bc57c883d4a4d6e3246905283d8dae951bb3bd32f49d6ef297f546e1c39"
 "checksum num-integer 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)" = "e83d528d2677f0518c570baf2b7abdcf0cd2d248860b68507bdcb3e91d4c0cea"
 "checksum num-traits 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "0b3a5d7cc97d6d30d8b9bc8fa19bf45349ffe46241e8816f50f62f6d6aaabee1"
 "checksum numtoa 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b8f8bdf33df195859076e54ab11ee78a1b208382d3a26ec40d142ffc1ecc49ef"
+"checksum opaque-debug 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "93f5bb2e8e8dec81642920ccff6b61f1eb94fa3020c5a325c9851ff604152409"
+"checksum pest 2.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "933085deae3f32071f135d799d75667b63c8dc1f4537159756e3d4ceab41868c"
+"checksum pest_derive 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "833d1ae558dc601e9a60366421196a8d94bc0ac980476d0b67e1d0988d72b2d0"
+"checksum pest_generator 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "63120576c4efd69615b5537d3d052257328a4ca82876771d6944424ccfd9f646"
+"checksum pest_meta 2.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f249ea6de7c7b7aba92b4ff4376a994c6dbd98fd2166c89d5c4947397ecb574d"
 "checksum proc-macro2 0.4.27 (registry+https://github.com/rust-lang/crates.io-index)" = "4d317f9caece796be1980837fd5cb3dfec5613ebdb04ad0956deea83ce168915"
+"checksum quick-error 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9274b940887ce9addde99c4eee6b5c44cc494b182b97e73dc8ffdcb3397fd3f0"
 "checksum quote 0.6.11 (registry+https://github.com/rust-lang/crates.io-index)" = "cdd8e04bd9c52e0342b406469d494fcb033be4bdbe5c606016defbb1681411e1"
 "checksum redox_syscall 0.1.51 (registry+https://github.com/rust-lang/crates.io-index)" = "423e376fffca3dfa06c9e9790a9ccd282fafb3cc6e6397d01dbf64f9bacc6b85"
 "checksum redox_termios 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7e891cfe48e9100a70a3b6eb652fef28920c117d366339687bd5576160db0f76"
+"checksum regex 1.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "8f0a0bcab2fd7d1d7c54fa9eae6f43eddeb9ce2e7352f8518a814a4f65d60c58"
+"checksum regex-syntax 0.6.6 (registry+https://github.com/rust-lang/crates.io-index)" = "dcfd8681eebe297b81d98498869d4aae052137651ad7b96822f09ceb690d0a96"
 "checksum rustc-demangle 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)" = "adacaae16d02b6ec37fdc7acfcddf365978de76d1983d3ee22afc260e1ca9619"
+"checksum ryu 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "b96a9549dc8d48f2c283938303c4b5a77aa29bfbc5b54b084fb1630408899a8f"
+"checksum same-file 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "8f20c4be53a8a1ff4c1f1b2bd14570d2f634628709752f0702ecdd2b3f9a5267"
 "checksum semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
 "checksum semver-parser 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 "checksum serde 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)" = "92514fb95f900c9b5126e32d020f5c6d40564c27a5ea6d1d7d9f157a96623560"
 "checksum serde_derive 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)" = "bb6eabf4b5914e88e24eea240bb7c9f9a2cbc1bbbe8d961d381975ec3c6b806c"
+"checksum serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)" = "5a23aa71d4a4d43fdbfaac00eff68ba8a06a51759a89ac3304323e800c4dd40d"
+"checksum sha-1 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "23962131a91661d643c98940b20fcaffe62d776a823247be80a48fcb8b6fce68"
 "checksum simplelog 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2e95345f185d5adeb8ec93459d2dc99654e294cc6ccf5b75414d8ea262de9a13"
 "checksum syn 0.14.9 (registry+https://github.com/rust-lang/crates.io-index)" = "261ae9ecaa397c42b960649561949d69311f08eeaea86a65696e6e46517cf741"
 "checksum syn 0.15.29 (registry+https://github.com/rust-lang/crates.io-index)" = "1825685f977249735d510a242a6727b46efe914bb67e38d30c071b1b72b1d5c2"
 "checksum synstructure 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "73687139bf99285483c96ac0add482c3776528beac1d97d444f6e91f203a2015"
 "checksum term 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "5e6b677dd1e8214ea1ef4297f85dbcbed8e8cdddb561040cc998ca2551c37561"
 "checksum termion 1.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "dde0593aeb8d47accea5392b39350015b5eccb12c0d98044d856983d89548dea"
+"checksum thread_local 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c6b53e329000edc2b34dbe8545fd20e55a333362d0a321909685a19bd28c3f1b"
 "checksum time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)" = "db8dcfca086c1143c9270ac42a2bbd8a7ee477b78ac8e45b19abfb0cbede4b6f"
 "checksum toml 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "87c5890a989fa47ecdc7bcb4c63a77a82c18f306714104b1decfd722db17b39e"
+"checksum typenum 1.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "612d636f949607bdf9b123b4a6f6d966dedf3ff669f7f045890d3a4a73948169"
+"checksum ucd-trie 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "71a9c5b1fe77426cf144cc30e49e955270f5086e31a6441dfa8b32efc09b9d77"
+"checksum ucd-util 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "535c204ee4d8434478593480b8f86ab45ec9aae0e83c568ca81abf0fd0e88f86"
+"checksum unicode-segmentation 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1967f4cdfc355b37fd76d2a954fb2ed3871034eb4f26d60537d88795cfc332a9"
 "checksum unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
+"checksum utf8-ranges 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "796f7e48bef87609f7ade7e06495a87d5cd06c7866e6a5cbfceffc558a243737"
+"checksum walkdir 2.2.7 (registry+https://github.com/rust-lang/crates.io-index)" = "9d9d7ed3431229a144296213105a390676cc49c9b6a72bd19f3176c98e129fa1"
 "checksum winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "92c1eb33641e276cfa214a0522acad57be5c56b10cb348b3c5117db75f3ac4b0"
 "checksum winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+"checksum winapi-util 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7168bab6e1daee33b4557efd0e95d5ca70a03706d39fa5f3fe7a236f584b03c9"
 "checksum winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 "checksum zeroize 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e68403b858b6af538b11614e62dfe9ab2facba9f13a0cafb974855cfb495ec95"
 "checksum zeroize_derive 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b3f07490820219949839d0027b965ffdd659d75be9220c00798762e36c6cd281"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,29 +12,28 @@ homepage    = "https://github.com/iqlusioninc/abscissa/"
 repository  = "https://github.com/iqlusioninc/abscissa/tree/develop/"
 readme      = "README.md"
 categories  = ["command-line-interface", "rust-patterns", "web-programming"]
-keywords    = ["application", "container", "microservices", "framework", "service"]
+keywords    = ["abscissa", "cli", "application", "framework", "service"]
 
 [dependencies]
 abscissa_derive = { version = "0", path = "abscissa_derive" }
+abscissa_generator = { version = "0", optional = true, path = "abscissa_generator" }
 atty = { version = "0.2", optional = true }
 canonical-path = "0.1"
 chrono = { version = "0.4", optional = true, features = ["serde"] }
 failure = "0.1"
 gumdrop = { version = "0.5", optional = true }
+gumdrop_derive = { version = "0.5", optional = true }
 lazy_static = "1"
 log = { version = "0.4", optional = true }
 semver = { version = "0.9", optional = true }
-serde = { version = "1", optional = true }
+serde = { version = "1", optional = true, features = ["serde_derive"] }
 simplelog = { version = "0.5", optional = true }
 term = { version = "0.5", optional = true }
 toml = { version = "0.5", optional = true }
 zeroize = "0.6"
 
-[dev-dependencies]
-serde_derive = "1.0"
-
 [features]
-default = ["application", "chrono"]
+default = ["application", "chrono", "generator"]
 application = [
     "config",
     "errors",
@@ -50,6 +49,9 @@ config = [
     "toml"
 ]
 errors = []
+generator = [
+    "abscissa_generator"
+]
 logging = [
     "errors",
     "log",
@@ -57,7 +59,8 @@ logging = [
 ]
 options = [
     "errors",
-    "gumdrop"
+    "gumdrop",
+    "gumdrop_derive"
 ]
 secrets = []
 shell = [
@@ -71,4 +74,4 @@ status = ["shell"]
 travis-ci = { repository = "iqlusioninc/abscissa", branch = "develop" }
 
 [workspace]
-members = [".", "abscissa_derive"]
+members = [".", "abscissa_derive", "abscissa_generator"]

--- a/README.md
+++ b/README.md
@@ -34,6 +34,19 @@ or network/web services), aiming to provide a large number of features with a
   support autodetection). Useful for Cargo-like status messages with
   easy-to-use macros.
 
+## Usage
+
+If you already have Rust installed, the following commands will generate an
+Abscissa application skeleton:
+
+```
+$ cargo install abscissa
+$ abscissa new my_cool_app
+```
+
+This will generate a new Abscissa application in the `my_cool_app` directory.
+For more information, please see the [Documentation].
+
 ## Depencencies
 
 *or: "Know Your Dependencies"*
@@ -150,6 +163,39 @@ In that regard, "Abscissa" can be thought of as a pun about getting off
 the ground, or elevating your project.
 
 The word "abscissa" is also the key to the [Kryptos K2] panel.
+
+## Testing Framework Changes
+
+The main way to test framework changes is by generating an application with
+Abscissa's built-in application generator and running tests against the
+generated application (also rustfmt, clippy).
+
+If you've already run:
+
+```
+$ git clone https://github.com/iqlusioninc/abscissa/
+```
+
+...and are inside the `abscissa` directory and want to test your changes,
+you can generate an application by running the following command:
+
+```
+$ cargo run -- new /tmp/example_app --patch-crates-io='abscissa = { path = "$PWD" }'
+```
+
+This will generate a new Abscissa application in `/tmp/example_app` which
+references your local copy of Abscissa.
+
+After that, change directory to the newly generated app and run the tests
+to ensure things are still working (the tests, along with rustfmt and clippy
+are run as part of the CI process):
+
+```
+$ cd /tmp/example_app # or 'pushd /tmp/example_app' and 'popd' to return
+$ cargo test
+$ cargo fmt -- --check # generated app is expected to pass rustfmt
+$ cargo clippy
+```
 
 ## License
 

--- a/abscissa_derive/src/lib.rs
+++ b/abscissa_derive/src/lib.rs
@@ -46,7 +46,7 @@ pub fn derive_command(input: TokenStream) -> TokenStream {
 
             #[doc = "Description of this program"]
             fn description() -> &'static str {
-                env!("CARGO_PKG_DESCRIPTION")
+                env!("CARGO_PKG_DESCRIPTION").trim()
             }
 
             #[doc = "Version of this program"]
@@ -63,3 +63,12 @@ pub fn derive_command(input: TokenStream) -> TokenStream {
 
     impl_command.into()
 }
+
+/// Custom derive for `abscissa::config::Config`
+fn derive_config(s: synstructure::Structure) -> proc_macro2::TokenStream {
+    s.gen_impl(quote! {
+        gen impl Config for @Self {
+        }
+    })
+}
+decl_derive!([Config] => derive_config);

--- a/abscissa_generator/Cargo.toml
+++ b/abscissa_generator/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+name        = "abscissa_generator"
+description = "Template-based generator for creating new Abscissa applications"
+version     = "0.0.0" # Also update html_root_url in lib.rs when bumping this
+license     = "Apache-2.0"
+authors     = ["Tony Arcieri <tony@iqlusion.io>"]
+edition     = "2018"
+homepage    = "https://github.com/iqlusioninc/abscissa"
+repository  = "https://github.com/iqlusioninc/abscissa/tree/develop/abscissa_generator"
+readme      = "README.md"
+categories  = ["rust-patterns"]
+keywords    = ["abscissa", "cli", "application", "framework", "service"]
+
+[badges]
+circle-ci = { repository = "iqlusioninc/abscissa", branch = "develop" }
+
+[dependencies]
+failure = "0.1"
+handlebars = "2.0.0-beta.2"
+hashbrown = "0.2"
+heck = "0.3"
+log = "0.4"
+semver = { version = "0.9", features = ["serde"] }
+serde = { version = "1", features = ["serde_derive"] }
+
+[package.metadata.docs.rs]
+rustdoc-args = ["--document-private-items"] # Document all modules

--- a/abscissa_generator/README.md
+++ b/abscissa_generator/README.md
@@ -1,6 +1,6 @@
 ![Abscissa](https://www.iqlusion.io/img/github/iqlusioninc/abscissa/abscissa.svg)
 
-# abscissa_derive: custom derive macros for Abscissa
+# abscissa_generator: generator for Abscissa applications
 
 [![Crate][crate-image]][crate-link]
 [![Docs][docs-image]][docs-link]
@@ -8,19 +8,23 @@
 [![Build Status][build-image]][build-link]
 [![Appveyor Status][appveyor-image]][appveyor-link]
 
-This crate provides the custom derive implementations used by the
-[Abscissa] command-line app microframework.
+This crate provides a generator for creating new [Abscissa] applications.
 
-Note that this crate isn't meant to be used directly, and you don't need to
-add it to your `Cargo.toml` file. Instead, just import the relevant types
-from Abscissa, and the proc macros will be in scope.
+Note that this crate isn't meant to be used directly, instead run:
+
+```
+$ cargo install abscissa
+```
+
+This crate powers the `abscissa new` subcommand. See the [Abscissa docs]
+for how to use it.
 
 ## License
 
-The **abscissa_derive** crate is distributed under the terms of the
+The **abscissa_generator** crate is distributed under the terms of the
 Apache License (Version 2.0).
 
-Copyright © 2018-2019 iqlusion
+Copyright © 2019 iqlusion
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -34,14 +38,15 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 
-[crate-image]: https://img.shields.io/crates/v/abscissa_derive.svg
-[crate-link]: https://crates.io/crates/abscissa_derive
-[docs-image]: https://docs.rs/abscissa_derive/badge.svg
-[docs-link]: https://docs.rs/abscissa_derive/
+[crate-image]: https://img.shields.io/crates/v/abscissa_generator.svg
+[crate-link]: https://crates.io/crates/abscissa_generator
+[docs-image]: https://docs.rs/abscissa_generator/badge.svg
+[docs-link]: https://docs.rs/abscissa_generator/
 [license-image]: https://img.shields.io/badge/license-Apache2.0-blue.svg
 [license-link]: https://github.com/iqlusioninc/abscissa/blob/develop/LICENSE
 [build-image]: https://travis-ci.org/iqlusioninc/abscissa.svg?branch=develop
 [build-link]: https://travis-ci.org/iqlusioninc/abscissa
 [appveyor-image]: https://ci.appveyor.com/api/projects/status/9bgh8je3rsmbyo0y?svg=true
 [appveyor-link]: https://ci.appveyor.com/project/tony-iqlusion/abscissa
-[Abscissa]: https://github.com/iqlusioninc/abscissa
+[Abscissa]: https://github.com/iqlusioninc/abscissa/
+[Abscissa docs]: https://docs.rs/abscissa/

--- a/abscissa_generator/src/lib.rs
+++ b/abscissa_generator/src/lib.rs
@@ -1,0 +1,15 @@
+//! Templating engine for generating new Abscissa applications
+
+#![deny(warnings, unsafe_code, unused_import_braces, unused_qualifications)]
+#![forbid(unsafe_code)]
+#![doc(
+    html_logo_url = "https://www.iqlusion.io/img/github/iqlusioninc/abscissa/abscissa-sq.svg",
+    html_root_url = "https://docs.rs/abscissa_generator/0.0.0"
+)]
+
+pub mod properties;
+pub mod template;
+
+pub use self::properties::Properties;
+pub use self::template::AppTemplate;
+pub use heck::CamelCase;

--- a/abscissa_generator/src/properties.rs
+++ b/abscissa_generator/src/properties.rs
@@ -1,0 +1,172 @@
+//! Application properties
+
+use super::CamelCase;
+pub use semver::Version;
+use serde::{Deserialize, Serialize};
+use std::{
+    fmt::{self, Display},
+    str::FromStr,
+};
+
+/// Application properties: configurable and computed values for names and
+/// other configurable values consumed from the templates.
+#[derive(Debug, Deserialize, Serialize)]
+pub struct Properties {
+    /// Abscissa-related properties
+    pub abscissa: FrameworkProperties,
+
+    /// Application name (i.e. crate name)
+    pub name: AppName,
+
+    /// Application title (longer, often capitalized name)
+    pub title: String,
+
+    /// Application description (i.e. crate description)
+    pub description: String,
+
+    /// Application authors,
+    pub authors: Vec<AuthorName>,
+
+    /// Application version
+    pub version: Version,
+
+    /// Rust edition to use
+    pub edition: Edition,
+
+    /// Apply patches to crates.io
+    pub patch_crates_io: Option<String>,
+
+    /// Application type name
+    pub application_type: TypeName,
+
+    /// Entrypoint command name
+    pub command_type: TypeName,
+
+    /// Configuration type name
+    pub config_type: TypeName,
+
+    /// Error type name
+    pub error_type: TypeName,
+
+    /// Error kind type name
+    pub error_kind_type: TypeName,
+}
+
+/// Default Cargo features to enable
+const DEFAULT_CARGO_FEATURES: &[&str] = &["application", "chrono"];
+
+/// Abscissa framework-related properties
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct FrameworkProperties {
+    /// Abscissa version
+    pub version: Version,
+
+    /// Cargo features to enable
+    pub cargo_features: Vec<CargoFeature>,
+}
+
+impl FrameworkProperties {
+    /// Create Abscissa framework properties
+    pub fn new(version: &str) -> Self {
+        Self {
+            version: Version::from_str(version).unwrap(),
+            cargo_features: DEFAULT_CARGO_FEATURES
+                .iter()
+                .map(|feature| feature.parse::<CargoFeature>().unwrap())
+                .collect(),
+        }
+    }
+}
+
+/// Cargo feature
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub struct CargoFeature(String);
+
+impl AsRef<str> for CargoFeature {
+    fn as_ref(&self) -> &str {
+        self.0.as_ref()
+    }
+}
+
+impl Display for CargoFeature {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl FromStr for CargoFeature {
+    type Err = ();
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Ok(CargoFeature(s.to_owned()))
+    }
+}
+
+/// Application name
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub struct AppName(String);
+
+impl AsRef<str> for AppName {
+    fn as_ref(&self) -> &str {
+        self.0.as_ref()
+    }
+}
+
+impl Display for AppName {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl FromStr for AppName {
+    type Err = ();
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Ok(AppName(s.to_owned()))
+    }
+}
+
+/// Author name
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub struct AuthorName(String);
+
+impl AsRef<str> for AuthorName {
+    fn as_ref(&self) -> &str {
+        self.0.as_ref()
+    }
+}
+
+impl From<String> for AuthorName {
+    fn from(s: String) -> AuthorName {
+        AuthorName(s)
+    }
+}
+
+/// Rust editions
+#[derive(Copy, Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub enum Edition {
+    /// Rust 2015 edition
+    #[serde(rename = "2015")]
+    Rust2015,
+
+    /// Rust 2018 edition
+    #[serde(rename = "2018")]
+    Rust2018,
+}
+
+/// Type names
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub struct TypeName(String);
+
+impl AsRef<str> for TypeName {
+    fn as_ref(&self) -> &str {
+        self.0.as_ref()
+    }
+}
+
+impl TypeName {
+    /// Inflect a snake case name into a type name
+    pub fn from_snake_case(s: &str) -> TypeName {
+        TypeName(s.to_camel_case())
+    }
+}

--- a/abscissa_generator/src/template.rs
+++ b/abscissa_generator/src/template.rs
@@ -1,0 +1,252 @@
+//! Abscissa application template renderer
+
+use crate::properties::Properties;
+use failure::{format_err, Error};
+use handlebars::Handlebars;
+use hashbrown::hash_map;
+use log::debug;
+use std::{
+    fmt, io,
+    path::{Path, PathBuf},
+};
+
+/// Include a file from the application template
+macro_rules! template {
+    ($path:expr) => {
+        ($path, include_str!(concat!("../template/", $path)))
+    };
+}
+
+/// Template files to render.
+///
+/// Right now all of these need to be declared explicitly, and end in `.hbs`
+const FILES: &[(&str, &str)] = &[
+    template!("Cargo.toml.hbs"),
+    template!("README.md.hbs"),
+    template!("src/application.rs.hbs"),
+    template!("src/bin/app/main.rs.hbs"),
+    template!("src/commands.rs.hbs"),
+    template!("src/commands/hello.rs.hbs"),
+    template!("src/commands/version.rs.hbs"),
+    template!("src/config.rs.hbs"),
+    template!("src/error.rs.hbs"),
+    template!("src/lib.rs.hbs"),
+];
+
+/// Abscissa application template renderer
+#[derive(Debug)]
+pub struct AppTemplate(Handlebars);
+
+impl Default for AppTemplate {
+    fn default() -> AppTemplate {
+        AppTemplate::new(
+            FILES
+                .iter()
+                .map(|(name, contents)| File::new(*name, *contents)),
+        )
+        .unwrap()
+    }
+}
+
+impl AppTemplate {
+    pub fn new<I>(template_files: I) -> Result<AppTemplate, Error>
+    where
+        I: IntoIterator<Item = File>,
+    {
+        let mut hbs = Handlebars::new();
+        hbs.set_strict_mode(true);
+        hbs.register_escape_fn(handlebars::no_escape);
+
+        for file in template_files.into_iter() {
+            debug!("registering template: {}", file.name);
+
+            hbs.register_template_string(file.name.as_ref(), file.contents.as_ref())
+                .map_err(|e| {
+                    format_err!("couldn't register template '{}': {}", file.name.as_ref(), e)
+                })?;
+        }
+
+        Ok(AppTemplate(hbs))
+    }
+
+    /// Iterate over the templates in the collection
+    pub fn iter(&self) -> Iter {
+        Iter::new(self.0.get_templates().iter())
+    }
+
+    /// Render a template
+    pub fn render<W>(
+        &self,
+        template: &TemplateEntry,
+        properties: &Properties,
+        output: W,
+    ) -> Result<(), Error>
+    where
+        W: io::Write,
+    {
+        let ctx = handlebars::Context::wraps(properties)?;
+        let mut render_context = handlebars::RenderContext::new(template.inner.name.as_ref());
+        let mut output = Output::new(output);
+
+        use handlebars::Renderable;
+        template
+            .inner
+            .render(&self.0, &ctx, &mut render_context, &mut output)
+            .map_err(|e| format_err!("render error: {}", e))
+    }
+}
+
+type HandlebarsIter<'a> = hash_map::Iter<'a, String, handlebars::Template>;
+
+/// Iterator over all registered template files
+pub struct Iter<'a>(HandlebarsIter<'a>);
+
+impl<'a> Iter<'a> {
+    fn new(templates: HandlebarsIter<'a>) -> Self {
+        Iter(templates)
+    }
+}
+
+impl<'a> Iterator for Iter<'a> {
+    type Item = TemplateEntry<'a>;
+
+    fn next(&mut self) -> Option<TemplateEntry<'a>> {
+        self.0
+            .next()
+            .map(|(path, template)| TemplateEntry::new(path.as_ref(), template))
+    }
+}
+
+/// Directory in an application template where binaries live
+const APP_BIN_DIR: &str = "src/bin/app";
+
+/// Template for an individual file
+pub struct TemplateEntry<'a> {
+    /// Template name
+    name: Name,
+
+    /// Inner Handlebars template
+    inner: &'a handlebars::Template,
+}
+
+impl<'a> TemplateEntry<'a> {
+    /// Make a new `TemplateEntry`
+    fn new(name: &'a str, template: &'a handlebars::Template) -> Self {
+        Self {
+            name: Name::from(name),
+            inner: template,
+        }
+    }
+
+    /// Get the template's name
+    pub fn name(&self) -> &Name {
+        &self.name
+    }
+}
+
+impl<'a> TemplateEntry<'a> {
+    /// Relative path in the application where the output file should be located
+    pub fn output_path(&self, properties: &Properties) -> PathBuf {
+        let path = Path::new(self.name().as_ref());
+
+        // Remove the '.hbs' extension (the `Name` type ensures we have one)
+        let stemmed_path = path
+            .parent()
+            .expect("no output parent path")
+            .join(path.file_stem().expect("no file stem"));
+
+        // If we're in the `src/bin/app` directory, rename 'app' appropriately
+        if stemmed_path.starts_with(APP_BIN_DIR) {
+            Path::new(APP_BIN_DIR)
+                .parent()
+                .unwrap()
+                .join(properties.name.as_ref())
+                .join(stemmed_path.strip_prefix(APP_BIN_DIR).unwrap())
+        } else {
+            stemmed_path
+        }
+    }
+}
+
+/// Wrapper for writing template output to a file
+struct Output<W: io::Write>(W);
+
+impl<W: io::Write> Output<W> {
+    pub fn new(writeable: W) -> Output<W> {
+        Output(writeable)
+    }
+}
+
+impl<W: io::Write> handlebars::Output for Output<W> {
+    fn write(&mut self, seg: &str) -> Result<(), io::Error> {
+        self.0.write_all(seg.as_bytes())
+    }
+}
+
+/// Individual template file
+#[derive(Debug)]
+pub struct File {
+    /// Name of a template file
+    name: Name,
+
+    /// Contents of the template
+    contents: Contents,
+}
+
+impl File {
+    fn new<N, C>(name: N, contents: C) -> File
+    where
+        N: Into<Name>,
+        C: Into<Contents>,
+    {
+        File {
+            name: name.into(),
+            contents: contents.into(),
+        }
+    }
+}
+
+/// Template names
+#[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
+pub struct Name(String);
+
+impl<'a> From<&'a str> for Name {
+    fn from(name: &'a str) -> Name {
+        assert!(name.ends_with(".hbs"), "template files must end with .hbs");
+        Name(name.to_owned())
+    }
+}
+
+impl AsRef<str> for Name {
+    fn as_ref(&self) -> &str {
+        self.0.as_ref()
+    }
+}
+
+impl fmt::Display for Name {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+/// Template file body
+#[derive(Clone, Debug)]
+pub struct Contents(String);
+
+impl<'a> From<&'a str> for Contents {
+    fn from(contents: &'a str) -> Contents {
+        Contents(contents.to_owned())
+    }
+}
+
+impl AsRef<str> for Contents {
+    fn as_ref(&self) -> &str {
+        self.0.as_ref()
+    }
+}
+
+impl fmt::Display for Contents {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}

--- a/abscissa_generator/template/.gitignore.hbs
+++ b/abscissa_generator/template/.gitignore.hbs
@@ -1,0 +1,2 @@
+/target
+**/*.rs.bk

--- a/abscissa_generator/template/Cargo.toml.hbs
+++ b/abscissa_generator/template/Cargo.toml.hbs
@@ -1,0 +1,24 @@
+[package]
+name = "{{name}}"
+authors = {{authors}}
+version = "{{version}}"
+edition = "{{edition}}"
+
+[dependencies]
+failure = "0.1"
+gumdrop = "0.5"
+lazy_static = "1"
+serde = { version = "1", features = ["serde_derive"] }
+
+[dependencies.abscissa]
+version = "{{abscissa.version}}"
+default-features = false
+features = [{{~#each abscissa.cargo_features~}}
+    "{{~this~}}"
+    {{~#unless @last}}, {{/unless~}}
+{{/each}}]
+
+{{#if patch_crates_io~}}
+[patch.crates-io]
+{{patch_crates_io}}
+{{/if~}}

--- a/abscissa_generator/template/README.md.hbs
+++ b/abscissa_generator/template/README.md.hbs
@@ -1,0 +1,14 @@
+# {{ title }}
+
+{{ description }} is an application.
+
+## Getting Started
+
+This application is authored using [Abscissa], a Rust application framework.
+
+For more information, see:
+
+[Documentation]
+
+[Abscissa]: https://github.com/iqlusioninc/abscissa
+[Documentation]: https://docs.rs/abscissa/

--- a/abscissa_generator/template/src/application.rs.hbs
+++ b/abscissa_generator/template/src/application.rs.hbs
@@ -1,0 +1,29 @@
+//! {{title}} Abscissa Application
+
+use crate::{
+    commands::{{~command_type~}},
+    config::{ {{~config_type~}}, APP_CONFIG},
+};
+use abscissa::{self, Application, EntryPoint, LoggingConfig};
+
+/// {{title}} Application
+#[derive(Debug)]
+pub struct {{application_type~}};
+
+impl Application for {{application_type}} {
+    type Cmd = EntryPoint<{{~command_type~}}>;
+    type Config = {{config_type~}};
+
+    /// Get a read lock on the application's global configuration
+    fn config(&self) -> abscissa::config::Reader<Self::Config> {
+        APP_CONFIG.get()
+    }
+
+    fn logging_config(&self, command: &EntryPoint<{{~command_type~}}>) -> LoggingConfig {
+        if command.verbose {
+            LoggingConfig::verbose()
+        } else {
+            LoggingConfig::default()
+        }
+    }
+}

--- a/abscissa_generator/template/src/bin/app/main.rs.hbs
+++ b/abscissa_generator/template/src/bin/app/main.rs.hbs
@@ -1,0 +1,9 @@
+//! Main entry point for {{title}}
+
+use {{name}}::application::{{~application_type~}};
+use {{name}}::config::APP_CONFIG;
+
+/// Boot {{title}}
+fn main() {
+    abscissa::boot({{~application_type~}}, &APP_CONFIG);
+}

--- a/abscissa_generator/template/src/commands.rs.hbs
+++ b/abscissa_generator/template/src/commands.rs.hbs
@@ -1,0 +1,28 @@
+//! {{title}} Subcommands
+
+mod hello;
+mod version;
+
+use self::{hello::HelloCommand, version::VersionCommand};
+use crate::config::{{~config_type~}};
+use abscissa::{config, Callable, Command, Options};
+use std::path::PathBuf;
+
+/// {{title}} Subcommands
+#[derive(Callable, Command, Debug, Options)]
+pub enum {{command_type}} {
+    /// The `hello` subcommand
+    #[options(help = "print hello world")]
+    Hello(HelloCommand),
+
+    /// The `version` subcommand
+    #[options(help = "display version information")]
+    Version(VersionCommand),
+}
+
+impl config::Loader<{{~config_type~}}> for {{command_type}} {
+    // TODO: parse configuration path from command-line options or `EntryPoint`
+    fn config_path(&self) -> Option<PathBuf> {
+        None
+    }
+}

--- a/abscissa_generator/template/src/commands/hello.rs.hbs
+++ b/abscissa_generator/template/src/commands/hello.rs.hbs
@@ -1,0 +1,27 @@
+//! `hello` subcommand - example of how to write a subcommand
+
+use abscissa::{Callable, Command, Options};
+
+/// `hello` subcommand
+///
+/// The `Options` proc macro generates an option parser based on the struct
+/// definition, and is defined in the `gumdrop` crate. See their documentation
+/// for a more comprehensive example:
+///
+/// <https://docs.rs/gumdrop/>
+#[derive(Command, Debug, Options)]
+pub struct HelloCommand {
+    /// To whom are we saying hello?
+    #[options(free)]
+    recipient: Option<String>,
+}
+
+impl Callable for HelloCommand {
+    /// Print "Hello, world!"
+    fn call(&self) {
+        match &self.recipient {
+            Some(recipient) => println!("Hello, {}!", recipient),
+            None => Self::print_usage(&[]),
+        }
+    }
+}

--- a/abscissa_generator/template/src/commands/version.rs.hbs
+++ b/abscissa_generator/template/src/commands/version.rs.hbs
@@ -1,0 +1,16 @@
+//! `version` subcommand
+
+#![allow(clippy::never_loop)]
+
+use abscissa::{Callable, Command, Options};
+
+/// `version` subcommand
+#[derive(Debug, Default, Options)]
+pub struct VersionCommand {}
+
+impl Callable for VersionCommand {
+    /// Print version message
+    fn call(&self) {
+        super::{{~command_type~}}::print_package_info();
+    }
+}

--- a/abscissa_generator/template/src/config.rs.hbs
+++ b/abscissa_generator/template/src/config.rs.hbs
@@ -1,0 +1,25 @@
+//! {{title}} Config
+
+use abscissa::config::{Config, Guard};
+use lazy_static::lazy_static;
+use serde::{Deserialize, Serialize};
+
+lazy_static! {
+    /// Application configuration
+    pub static ref APP_CONFIG: Guard<{{~config_type~}}> = Guard::default();
+}
+
+/// {{title}} Configuration
+#[derive(Clone, Config, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct {{config_type}} {
+    /// An example configuration section
+    pub example_section: ExampleSection,
+}
+
+/// Example configuration section
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct ExampleSection {
+    /// Example configuration value
+    pub example_value: String,
+}

--- a/abscissa_generator/template/src/error.rs.hbs
+++ b/abscissa_generator/template/src/error.rs.hbs
@@ -1,0 +1,39 @@
+//! Error types
+
+use abscissa::{err, Error};
+use failure::Fail;
+use std::{fmt, io};
+
+/// Error type
+#[derive(Debug)]
+pub struct {{error_type}}(Error<{{error_kind_type}}>);
+
+/// Kinds of errors
+#[derive(Copy, Clone, Eq, PartialEq, Debug, Fail)]
+pub enum {{error_kind_type}} {
+    /// Error in configuration file
+    #[fail(display = "config error")]
+    Config,
+
+    /// Input/output error
+    #[fail(display = "I/O error")]
+    Io,
+}
+
+impl fmt::Display for {{error_type}} {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+impl From<Error<{{error_kind_type}}>> for {{error_type}} {
+    fn from(other: Error<{{error_kind_type}}>) -> Self {
+        {{error_type}}(other)
+    }
+}
+
+impl From<io::Error> for {{error_type}} {
+    fn from(other: io::Error) -> Self {
+        err!({{error_kind_type}}::Io, other).into()
+    }
+}

--- a/abscissa_generator/template/src/lib.rs.hbs
+++ b/abscissa_generator/template/src/lib.rs.hbs
@@ -1,0 +1,18 @@
+//! {{title}}
+//!
+//! {{description}}
+
+#![deny(
+    warnings,
+    missing_docs,
+    trivial_casts,
+    trivial_numeric_casts,
+    unused_import_braces,
+    unused_qualifications
+)]
+#![forbid(unsafe_code)]
+
+pub mod application;
+pub mod commands;
+pub mod config;
+pub mod error;

--- a/src/application.rs
+++ b/src/application.rs
@@ -1,10 +1,12 @@
 //! Trait for representing an Abscissa application and it's lifecycle
 
 mod components;
+mod exit;
 
-use std::str::FromStr;
-pub mod exit;
-pub use self::components::{Component, Components};
+pub use self::{
+    components::{Component, Components},
+    exit::*,
+};
 use crate::{
     command::Command,
     config::{self, Config, Loader as _},
@@ -13,6 +15,7 @@ use crate::{
     shell::{ColorConfig, ShellComponent},
     util::{self, CanonicalPathBuf, Version},
 };
+use std::str::FromStr;
 
 /// Core Abscissa trait used for managing the application lifecycle.
 /// Core Abscissa trait used for managing the application lifecycle.
@@ -30,9 +33,6 @@ pub trait Application: Send + Sized + Sync {
 
     /// Configuration type used by this application
     type Config: Config;
-
-    /// Boot the application
-    fn boot() -> !;
 
     /// Get a read lock on the application's global configuration
     fn config(&self) -> config::Reader<Self::Config>;
@@ -123,7 +123,7 @@ pub trait Application: Send + Sized + Sync {
 
     /// Shut down this application gracefully, exiting with success
     fn shutdown(&self, components: Components) -> ! {
-        exit::shutdown(self, components)
+        shutdown(self, components)
     }
 }
 

--- a/src/bin/abscissa/application.rs
+++ b/src/bin/abscissa/application.rs
@@ -1,0 +1,29 @@
+//! Abscissa CLI Application
+
+use super::{
+    commands::CliCommand,
+    config::{CliConfig, APP_CONFIG},
+};
+use abscissa::{self, Application, EntryPoint, LoggingConfig};
+
+/// Abscissa CLI Application
+#[derive(Debug)]
+pub struct CliApplication;
+
+impl Application for CliApplication {
+    type Cmd = EntryPoint<CliCommand>;
+    type Config = CliConfig;
+
+    /// Get a read lock on the application's global configuration
+    fn config(&self) -> abscissa::config::Reader<Self::Config> {
+        APP_CONFIG.get()
+    }
+
+    fn logging_config(&self, command: &EntryPoint<CliCommand>) -> LoggingConfig {
+        if command.verbose {
+            LoggingConfig::verbose()
+        } else {
+            LoggingConfig::default()
+        }
+    }
+}

--- a/src/bin/abscissa/commands.rs
+++ b/src/bin/abscissa/commands.rs
@@ -1,0 +1,25 @@
+//! Abscissa CLI Subcommands
+
+mod new;
+mod version;
+
+use self::{new::NewCommand, version::VersionCommand};
+use super::config::CliConfig;
+use abscissa::{config, Callable, Command, Options};
+use std::path::PathBuf;
+
+/// Abscissa CLI Subcommands
+#[derive(Callable, Command, Debug, Options)]
+pub enum CliCommand {
+    #[options(help = "create a new Abscissa application from a template")]
+    New(NewCommand),
+
+    #[options(help = "display version information")]
+    Version(VersionCommand),
+}
+
+impl config::Loader<CliConfig> for CliCommand {
+    fn config_path(&self) -> Option<PathBuf> {
+        None
+    }
+}

--- a/src/bin/abscissa/commands/new.rs
+++ b/src/bin/abscissa/commands/new.rs
@@ -1,0 +1,190 @@
+//! `generate` subcommand - generate a new Abscissa application
+
+#![allow(clippy::never_loop)]
+
+use abscissa::{status_err, status_ok, Callable, Command, Options};
+use abscissa_generator::{
+    properties::{AppName, Edition, FrameworkProperties, Properties, TypeName},
+    template::{AppTemplate, TemplateEntry},
+    CamelCase,
+};
+use failure::{bail, format_err, Error};
+use std::{
+    fs,
+    path::{Path, PathBuf},
+    process,
+    str::FromStr,
+    time::Instant,
+};
+
+/// `new` subcommand - generate a new Abscissa application
+#[derive(Command, Debug, Default, Options)]
+pub struct NewCommand {
+    /// Add a `[patch.crates-io]` section to Cargo.toml
+    #[options(no_short, help = "add patch.crates-io to Cargo.toml")]
+    patch_crates_io: Option<String>,
+
+    /// Path to the newly generated application
+    #[options(free)]
+    app_path: Option<PathBuf>,
+}
+
+impl Callable for NewCommand {
+    /// Run the Abscissa application generator
+    fn call(&self) {
+        let started_at = Instant::now();
+        let app_properties = self.parse_options().unwrap_or_else(|e| fatal_error(e));
+        let app_template = AppTemplate::default();
+
+        self.create_parent_directory()
+            .unwrap_or_else(|e| fatal_error(e));
+
+        // Sort template files alphabetically
+        let mut template_files = app_template.iter().collect::<Vec<_>>();
+        template_files.sort_by(|a, b| a.name().cmp(b.name()));
+
+        for template_file in &template_files {
+            self.render_template_file(&app_template, &template_file, &app_properties)
+                .unwrap_or_else(|e| fatal_error(e));
+        }
+
+        let duration = started_at.elapsed();
+
+        status_ok!(
+            "Finished",
+            "`{}` generated in {:.2}s",
+            &app_properties.name,
+            duration.as_secs() as f64 + f64::from(duration.subsec_nanos()) * 1e-9
+        );
+    }
+}
+
+impl NewCommand {
+    /// Get the path to the newly generated application
+    fn app_path(&self) -> Result<&Path, Error> {
+        match &self.app_path {
+            Some(path) => Ok(path.as_ref()),
+            None => bail!("no app_path given"),
+        }
+    }
+
+    /// Create the parent directory for the newly generated application (if necessary)
+    fn create_parent_directory(&self) -> Result<(), Error> {
+        let app_path = self.app_path()?;
+
+        if app_path.exists() {
+            fatal_error(format_err!(
+                "destination `{}` already exists",
+                app_path.display()
+            ));
+        }
+
+        fs::create_dir(app_path)
+            .map_err(|e| format_err!("couldn't create {}: {}", app_path.display(), e))?;
+
+        status_ok!(
+            "Created",
+            "`{}` (application directory)",
+            app_path.display()
+        );
+
+        Ok(())
+    }
+
+    /// Render an individual template file
+    fn render_template_file(
+        &self,
+        app_template: &AppTemplate,
+        template_file: &TemplateEntry,
+        app_properties: &Properties,
+    ) -> Result<(), Error> {
+        let output_path_rel = template_file.output_path(app_properties);
+        let output_path = self.app_path()?.join(&output_path_rel);
+
+        if output_path.exists() {
+            fatal_error(format_err!(
+                "file already exists: {}",
+                output_path.display()
+            ));
+        }
+
+        // We should always have a parent directory
+        let output_dir = output_path.parent().unwrap();
+
+        // Create all of the necessary parent directories
+        fs::create_dir_all(output_dir)
+            .map_err(|e| format_err!("error creating {}: {}", output_dir.display(), e))?;
+
+        let mut output_file = fs::File::create(&output_path)
+            .map_err(|e| format_err!("couldn't create {}: {}", output_path.display(), e))?;
+
+        app_template.render(template_file, &app_properties, &mut output_file)?;
+
+        status_ok!("Created", "new file: {}", output_path_rel.display());
+
+        Ok(())
+    }
+
+    /// Parse `abscissa_generate` properties from command-line options
+    fn parse_options(&self) -> Result<Properties, Error> {
+        let abscissa = FrameworkProperties::new(abscissa::VERSION);
+        let app_path = self.app_path()?;
+
+        let app_name = app_path
+            .file_name()
+            .expect("no filename?")
+            .to_string_lossy();
+
+        let name = AppName::from_str(&app_name).expect("no app name");
+
+        // TODO(tarcieri): configurable title
+        let title = name.to_string().to_camel_case();
+
+        // TODO(tarcieri): configurable description
+        let description = title.to_string();
+
+        // TODO(tarcieri): configurable edition
+        let edition = Edition::Rust2018;
+
+        let patch_crates_io = self.patch_crates_io.clone();
+
+        // TODO(tarcieri): configurable application type
+        let application_type = TypeName::from_snake_case(&(app_name.clone() + "_application"));
+
+        // TODO(tarcieri): configurable command type
+        let command_type = TypeName::from_snake_case(&(app_name.clone() + "_command"));
+
+        // TODO(tarcieri): configurable config type
+        let config_type = TypeName::from_snake_case(&(app_name.clone() + "_config"));
+
+        // TODO(tarcieri): configurable error type
+        let error_type = TypeName::from_snake_case(&(app_name.clone() + "_error"));
+
+        // TODO(tarcieri): configurable error kind type
+        let error_kind_type = TypeName::from_snake_case(&(app_name.clone() + "_error_kind"));
+
+        let properties = Properties {
+            abscissa,
+            name,
+            title,
+            description,
+            authors: vec![],
+            version: "0.1.0".parse().unwrap(),
+            edition,
+            patch_crates_io,
+            application_type,
+            command_type,
+            config_type,
+            error_type,
+            error_kind_type,
+        };
+
+        Ok(properties)
+    }
+}
+
+/// Print a fatal error message and exit
+pub fn fatal_error(err: Error) -> ! {
+    status_err!("{}", err);
+    process::exit(1)
+}

--- a/src/bin/abscissa/commands/version.rs
+++ b/src/bin/abscissa/commands/version.rs
@@ -1,0 +1,16 @@
+//! `version` subcommand
+
+#![allow(clippy::never_loop)]
+
+use abscissa::{Callable, Command, Options};
+
+/// `version` subcommand
+#[derive(Debug, Default, Options)]
+pub struct VersionCommand {}
+
+impl Callable for VersionCommand {
+    /// Print version message
+    fn call(&self) {
+        super::CliCommand::print_package_info();
+    }
+}

--- a/src/bin/abscissa/config.rs
+++ b/src/bin/abscissa/config.rs
@@ -1,0 +1,25 @@
+//! Abscissa CLI Config
+
+use abscissa::config::{Config, Guard};
+use lazy_static::lazy_static;
+use serde::{Deserialize, Serialize};
+
+lazy_static! {
+    /// Application configuration
+    pub static ref APP_CONFIG: Guard<CliConfig> = Guard::default();
+}
+
+/// Abscissa CLI Config
+#[derive(Config, Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct CliConfig {
+    /// An example configuration section
+    pub example_section: ExampleSection,
+}
+
+/// Example configuration section
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct ExampleSection {
+    /// Example configuration value
+    pub example_value: String,
+}

--- a/src/bin/abscissa/main.rs
+++ b/src/bin/abscissa/main.rs
@@ -1,0 +1,13 @@
+//! Main entry point for the Abscissa CLI application
+
+mod application;
+mod commands;
+mod config;
+
+use self::application::CliApplication;
+use self::config::APP_CONFIG;
+
+/// Boot Abscissa CLI
+fn main() {
+    abscissa::boot(CliApplication, &APP_CONFIG);
+}

--- a/src/command/entrypoint.rs
+++ b/src/command/entrypoint.rs
@@ -1,0 +1,86 @@
+//! Toplevel entrypoint command.
+
+use crate::{config, Callable, Command, Options};
+use std::path::PathBuf;
+
+/// Toplevel entrypoint command.
+///
+/// Handles obtaining toplevel help as well as verbosity settings.
+#[derive(Debug, Options)]
+pub struct EntryPoint<Cmd: Callable + Command> {
+    /// Path to the configuration file
+    #[options(help = "path to configuration file")]
+    pub config: Option<PathBuf>,
+
+    /// Obtain help about the current command
+    #[options(help = "print help message")]
+    pub help: bool,
+
+    /// Increase verbosity setting
+    #[options(help = "be verbose")]
+    pub verbose: bool,
+
+    /// Subcommand to execute.
+    ///
+    /// The `command` option will delegate option parsing to the command type,
+    /// starting at the first free argument.
+    #[options(command)]
+    pub command: Option<Cmd>,
+}
+
+impl<Cmd> EntryPoint<Cmd>
+where
+    Cmd: Callable + Command,
+{
+    /// Borrow the underlying command type or print usage info and exit
+    fn command(&self) -> &Cmd {
+        self.command
+            .as_ref()
+            .unwrap_or_else(|| Cmd::print_usage(&[]))
+    }
+}
+
+impl<Cmd> Callable for EntryPoint<Cmd>
+where
+    Cmd: Callable + Command,
+{
+    fn call(&self) {
+        self.command().call()
+    }
+}
+
+impl<Cmd> Command for EntryPoint<Cmd>
+where
+    Cmd: Callable + Command,
+{
+    /// Name of this program as a string
+    fn name() -> &'static str {
+        Cmd::name()
+    }
+
+    /// Description of this program
+    fn description() -> &'static str {
+        Cmd::description()
+    }
+
+    /// Version of this program
+    fn version() -> &'static str {
+        Cmd::version()
+    }
+
+    /// Authors of this program
+    fn authors() -> &'static str {
+        Cmd::authors()
+    }
+}
+
+impl<Cfg, Cmd> config::Loader<Cfg> for EntryPoint<Cmd>
+where
+    Cmd: Callable + Command + config::Loader<Cfg>,
+    Cfg: config::Config,
+{
+    /// Path to the command's configuration file. Returns an error by default.
+    fn config_path(&self) -> Option<PathBuf> {
+        self.command.as_ref().and_then(config::Loader::config_path)
+    }
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -9,6 +9,8 @@ use crate::{
     error::{FrameworkError, FrameworkErrorKind::ConfigError},
     util::CanonicalPath,
 };
+#[doc(hidden)]
+pub use abscissa_derive::Config;
 use serde::{de::DeserializeOwned, Serialize};
 use std::{fmt::Debug, fs::File, io::Read};
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,11 +23,49 @@
 //!   support autodetection). Useful for Cargo-like status messages with
 //!   easy-to-use macros.
 //!
-//! [gumdrop]: https://github.com/murarth/gumdrop
-//! [RwLock]: https://doc.rust-lang.org/std/sync/struct.RwLock.html
-//! [lazy_static]: https://docs.rs/lazy_static
+//! # Creating a new Abscissa application
+//!
+//! If you already have Rust installed, the following commands will generate an
+//! Abscissa application skeleton:
+//!
+//! ```text
+//! $ cargo install abscissa
+//! $ abscissa new my_cool_app
+//! ```
+//!
+//! The resulting app is a Cargo project. The following files are particularly
+//! noteworthy:
+//!
+//! - `src/application.rs`: Abscissa application type for your app
+//! - `src/commands*`: application entrypoint and subcommands. Make sure to
+//!   check out the `hello.rs` example of how to make a subcommand.
+//! - `src/config.rs`: application configuration
+//! - `src/error.rs`: error types
+//!
+//! Abscissa applications are implemented as Rust libraries, but have a
+//! `src/bin` subdirectory where the binary entrypoint lives. This means you
+//! can run the following within your newly generated application:
+//!
+//! ```text
+//! $ cargo run -- hello world
+//! ```
+//!
+//! This will invoke the `hello` subcommand of your application (you'll
+//! probably want to rename that in a real app) which will print the following:
+//!
+//! ```text
+//! Hello, world!
+//! ```
+//!
+//! You can also run the following to print basic help information:
+//!
+//! ```text
+//! $ cargo run -- --help
+//! ```
 //!
 //! # Option Parser
+//!
+//! Command-line options are parsed using the [gumdrop] crate.
 //!
 //! Please see the documentation for the `options` module.
 //!
@@ -49,6 +87,10 @@
 //! status_attr_err!("error", "yep");
 //! # }
 //! ```
+//!
+//! [gumdrop]: https://github.com/murarth/gumdrop
+//! [RwLock]: https://doc.rust-lang.org/std/sync/struct.RwLock.html
+//! [lazy_static]: https://docs.rs/lazy_static
 
 #![deny(
     warnings,
@@ -62,6 +104,9 @@
     html_root_url = "https://docs.rs/abscissa/0.0.6"
 )]
 
+/// Abscissa version
+pub const VERSION: &str = env!("CARGO_PKG_VERSION");
+
 #[cfg(feature = "logging")]
 pub use log;
 
@@ -70,7 +115,7 @@ pub use log;
 pub mod macros;
 
 #[cfg(feature = "application")]
-mod application;
+pub mod application;
 #[cfg(feature = "options")]
 mod callable;
 #[cfg(feature = "options")]
@@ -88,16 +133,18 @@ pub mod shell;
 pub mod util;
 
 #[doc(hidden)]
-pub use abscissa_derive::*;
+pub use abscissa_derive::{Callable, Command};
 #[cfg(feature = "options")]
 pub use gumdrop::Options;
+#[cfg(feature = "options")]
+pub use gumdrop_derive::*;
 
 #[cfg(feature = "application")]
 pub use application::{boot, Application, ApplicationPath, Component, Components};
 #[cfg(feature = "options")]
 pub use callable::Callable;
 #[cfg(feature = "options")]
-pub use command::Command;
+pub use command::{Command, EntryPoint};
 #[cfg(feature = "config")]
 pub use config::Config;
 #[cfg(feature = "errors")]

--- a/src/macros/status.rs
+++ b/src/macros/status.rs
@@ -47,7 +47,7 @@ macro_rules! status {
         $crate::status($stream, $color, $status, $msg, true);
     };
     ($stream:expr, $color:expr, $status:expr, $fmt:expr, $($arg:tt)+) => {
-        status!($stream, $color, $status, format!($fmt, $($arg)+));
+        $crate::status!($stream, $color, $status, format!($fmt, $($arg)+));
     };
 }
 
@@ -58,7 +58,7 @@ macro_rules! status_nojust {
         $crate::status($stream, $color, $status, $msg, false);
     };
     ($stream:expr, $color:expr, $status:expr, $fmt:expr, $($arg:tt)+) => {
-        status!($stream, $color, $status, format!($fmt, $($arg)+));
+        $crate::status!($stream, $color, $status, format!($fmt, $($arg)+));
     };
 }
 
@@ -74,10 +74,10 @@ macro_rules! status_nojust {
 #[macro_export]
 macro_rules! status_ok {
     ($status:expr, $msg:expr) => {
-        status!($crate::Stream::Stdout, $crate::shell::color::GREEN, $status, $msg);
+        $crate::status!($crate::Stream::Stdout, $crate::shell::color::GREEN, $status, $msg);
     };
     ($status:expr, $fmt:expr, $($arg:tt)+) => {
-        status_ok!($status, format!($fmt, $($arg)+));
+        $crate::status_ok!($status, format!($fmt, $($arg)+));
     };
 }
 
@@ -93,10 +93,10 @@ macro_rules! status_ok {
 #[macro_export]
 macro_rules! status_info {
     ($status:expr, $msg:expr) => {
-        status!($crate::Stream::Stdout, $crate::shell::color::BRIGHT_CYAN, $status, $msg);
+        $crate::status!($crate::Stream::Stdout, $crate::shell::color::BRIGHT_CYAN, $status, $msg);
     };
     ($status:expr, $fmt:expr, $($arg:tt)+) => {
-        status_info!($status, format!($fmt, $($arg)+));
+        $crate::status_info!($status, format!($fmt, $($arg)+));
     };
 }
 
@@ -112,10 +112,10 @@ macro_rules! status_info {
 #[macro_export]
 macro_rules! status_warn {
     ($msg:expr) => {
-        status_nojust!($crate::Stream::Stdout, $crate::shell::color::YELLOW, "warning:", $msg);
+        $crate::status_nojust!($crate::Stream::Stdout, $crate::shell::color::YELLOW, "warning:", $msg);
     };
     ($fmt:expr, $($arg:tt)+) => {
-        status_warn!(format!($fmt, $($arg)+));
+        $crate::status_warn!(format!($fmt, $($arg)+));
     };
 }
 
@@ -131,10 +131,10 @@ macro_rules! status_warn {
 #[macro_export]
 macro_rules! status_err {
     ($msg:expr) => {
-        status_nojust!($crate::Stream::Stderr, $crate::shell::color::RED, "error:", $msg);
+        $crate::status_nojust!($crate::Stream::Stderr, $crate::shell::color::RED, "error:", $msg);
     };
     ($fmt:expr, $($arg:tt)+) => {
-        status_err!(format!($fmt, $($arg)+));
+        $crate::status_err!(format!($fmt, $($arg)+));
     };
 }
 
@@ -149,7 +149,7 @@ macro_rules! status_attr {
             format!("{}:\t", $attr)
         };
 
-        status_nojust!(
+        $crate::status_nojust!(
             $stream,
             $color,
             attr_delimited,
@@ -173,10 +173,10 @@ macro_rules! status_attr {
 #[macro_export]
 macro_rules! status_attr_ok {
     ($attr:expr, $msg:expr) => {
-        status_attr!($crate::Stream::Stdout, $crate::shell::color::GREEN, $attr, $msg);
+        $crate::status_attr!($crate::Stream::Stdout, $crate::shell::color::GREEN, $attr, $msg);
     };
     ($attr: expr, $fmt:expr, $($arg:tt)+) => {
-        status_attr_ok!($attr, format!($fmt, $($arg)+));
+        $crate::status_attr_ok!($attr, format!($fmt, $($arg)+));
     }
 }
 
@@ -192,9 +192,9 @@ macro_rules! status_attr_ok {
 #[macro_export]
 macro_rules! status_attr_err {
     ($attr:expr, $msg:expr) => {
-        status_attr!($crate::Stream::Stderr, $crate::shell::color::RED, $attr, $msg);
+        $crate::status_attr!($crate::Stream::Stderr, $crate::shell::color::RED, $attr, $msg);
     };
     ($attr: expr, $fmt:expr, $($arg:tt)+) => {
-        status_attr_err!($attr, format!($fmt, $($arg)+));
+        $crate::status_attr_err!($attr, format!($fmt, $($arg)+));
     }
 }


### PR DESCRIPTION
Adds support for generating new Abscissa apps from a built-in template.

Prior to this there was not a template for creating new Abscissa apps, and wiring them up either involved looking through an existing app, or intimate knowledge of how the framework works.

This adds a new `abscissa_generator` crate, and also adds a `src/bin/abscissa` making this crate into a binary crate which contains an `abscissa` command-line application (itself a proper Abscissa app!) which will be available when `cargo install abscissa` is used.

The application template is implemented using Handlebars, and vendored into the `abscissa_generator` crate (which is not included by applications). The decision to use Handlebars was made after evaluating a few different options for templating rust apps including
`cargo-generate` (which looks cool, but it seems like Abscissa could benefit from something which both lives in the same git repo and is more directly integrated with the framework, ala Rails)