### PR TITLE
Bump minimum Rust version to 1.35.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,4 @@
 language: rust
-rust: stable
-os: linux
 cache: cargo
 
 install:
@@ -15,25 +13,42 @@ branches:
 matrix:
   include:
     - name: audit
+      rust: stable
+      os: linux
       script:
         - cargo audit
     - name: rustfmt
+      rust: stable
+      os: linux
       script:
         - cargo fmt -- --check
     - name: clippy
+      rust: stable
       script:
         - cargo clippy
     - name: build
+      rust: stable
+      os: linux
       script:
         - cargo build --no-default-features --lib
         - cargo build --release --all --all-features
-    - name: test
+    - name: test (rustc 1.35.0)
+      rust: 1.35.0
+      os: linux
       script:
         - cargo test --release --all --all-features
-    - name: test (Rust 1.34.0)
-      rust: 1.34.0
+    - name: test (rustc stable)
+      rust: stable
+      os: linux
+      script:
+        - cargo test --release --all --all-features
+    - name: test (rustc stable/osx)
+      rust: stable
+      os: osx
       script:
         - cargo test --release --all --all-features
     - name: doc
+      rust: stable
+      os: linux
       script:
         - cargo doc --all --all-features

--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 [![Crate][crate-image]][crate-link]
 [![Docs][docs-image]][docs-link]
 [![Apache 2.0 Licensed][license-image]][license-link]
+![Rust 1.35+][rustc-image]
+[![forbid(unsafe_code)][unsafe-image]][unsafe-link]
 [![Build Status][build-image]][build-link]
 [![Appveyor Status][appveyor-image]][appveyor-link]
 
@@ -40,7 +42,7 @@ or network/web services), aiming to provide a large number of features with a
 
 ## Requirements
 
-- Rust 1.34+
+- Rust 1.35+
 
 ## Usage
 
@@ -249,6 +251,9 @@ without any additional terms or conditions.
 [docs-link]: https://docs.rs/abscissa/
 [license-image]: https://img.shields.io/badge/license-Apache2.0-blue.svg
 [license-link]: https://github.com/iqlusioninc/abscissa/blob/develop/LICENSE
+[rustc-image]: https://img.shields.io/badge/rustc-1.35+-blue.svg
+[unsafe-image]: https://img.shields.io/badge/unsafe-forbidden-success.svg
+[unsafe-link]: https://internals.rust-lang.org/t/disabling-unsafe-by-default/7988
 [build-image]: https://travis-ci.com/iqlusioninc/abscissa.svg?branch=develop
 [build-link]: https://travis-ci.com/iqlusioninc/abscissa/
 [appveyor-image]: https://ci.appveyor.com/api/projects/status/9bgh8je3rsmbyo0y?svg=true

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,9 +2,12 @@ os: Visual Studio 2017
 
 environment:
   matrix:
-    - channel: stable
+    # Minimum supported rustc
+    - channel: 1.35.0
       target: x86_64-pc-windows-msvc
-    - channel: 1.34.0
+
+    # Stable channel should always be supported too
+    - channel: stable
       target: x86_64-pc-windows-msvc
 
 branches:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -92,13 +92,8 @@
 //! [RwLock]: https://doc.rust-lang.org/std/sync/struct.RwLock.html
 //! [lazy_static]: https://docs.rs/lazy_static
 
-#![deny(
-    warnings,
-    missing_docs,
-    unsafe_code,
-    unused_import_braces,
-    unused_qualifications
-)]
+#![deny(warnings, missing_docs, unused_import_braces, unused_qualifications)]
+#![forbid(unsafe_code)]
 #![doc(
     html_logo_url = "https://www.iqlusion.io/img/github/iqlusioninc/abscissa/abscissa-sq.svg",
     html_root_url = "https://docs.rs/abscissa/0.0.6"


### PR DESCRIPTION
Notably `Box<Fn*>` was stabilized and is quite useful.

This should, hopefully, represent a minimum version we'll be able to stick with for awhile.