### PR TITLE
Impl Runnable/RunnableMut for Box<dyn Fn/FnMut>

### DIFF
--- a/src/runnable.rs
+++ b/src/runnable.rs
@@ -4,10 +4,27 @@
 /// arguments.
 ///
 /// Its primary intended purpose is for use in conjunction with `Command`.
-
 pub trait Runnable {
-    /// Call this callable (i.e. command), running its behavior
+    /// Run this `Runnable`
     fn run(&self);
+}
+
+/// `RunnableMut` is a `Runnable` that takes a mutable reference to `self`.
+pub trait RunnableMut {
+    /// Run this `RunnableMut`
+    fn run(&mut self);
+}
+
+impl Runnable for Box<dyn Fn() -> ()> {
+    fn run(&self) {
+        self();
+    }
+}
+
+impl RunnableMut for Box<dyn FnMut() -> ()> {
+    fn run(&mut self) {
+        self();
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Rust 1.35 added support for `Box<dyn Fn>` and `Box<dyn FnMut>`.

We're officially now 1.35+, so add `Runnable`/`RunnableMut` impls for these respectively.

It's convenient to be able to create anonynous `Runnable`s out of boxed closures.