### PR TITLE
abscissa_derive: Test all proc macros

### DIFF
--- a/abscissa_derive/src/command.rs
+++ b/abscissa_derive/src/command.rs
@@ -1,0 +1,70 @@
+use quote::quote;
+
+/// Custom derive for `abscissa::command::Command`
+pub fn derive_command(s: synstructure::Structure) -> proc_macro2::TokenStream {
+    s.gen_impl(quote! {
+        gen impl Command for @Self {
+            #[doc = "Name of this program as a string"]
+            fn name() -> &'static str {
+                env!("CARGO_PKG_NAME")
+            }
+
+            #[doc = "Description of this program"]
+            fn description() -> &'static str {
+                env!("CARGO_PKG_DESCRIPTION").trim()
+            }
+
+            #[doc = "Version of this program"]
+            fn version() -> &'static str {
+                env!("CARGO_PKG_VERSION")
+            }
+
+            #[doc = "Authors of this program"]
+            fn authors() -> &'static str {
+                env!("CARGO_PKG_AUTHORS")
+            }
+        }
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use synstructure::test_derive;
+
+    #[test]
+    fn derive_command_on_struct() {
+        test_derive! {
+            derive_command {
+                struct MyCommand {}
+            }
+            expands to {
+                #[allow(non_upper_case_globals)]
+                const _DERIVE_Command_FOR_MyCommand: () = {
+                    impl Command for MyCommand {
+                        #[doc = "Name of this program as a string"]
+                        fn name() -> & 'static str {
+                            env!("CARGO_PKG_NAME")
+                        }
+
+                        #[doc = "Description of this program"]
+                        fn description () -> & 'static str {
+                            env!("CARGO_PKG_DESCRIPTION" ).trim()
+                        }
+
+                        #[doc = "Version of this program"]
+                        fn version() -> & 'static str {
+                            env!( "CARGO_PKG_VERSION")
+                        }
+
+                        #[doc = "Authors of this program"]
+                        fn authors() -> & 'static str {
+                            env!("CARGO_PKG_AUTHORS")
+                        }
+                    }
+                };
+            }
+            no_build // tests the code compiles are in the `abscissa` crate
+        }
+    }
+}

--- a/abscissa_derive/src/config.rs
+++ b/abscissa_derive/src/config.rs
@@ -1,0 +1,32 @@
+use quote::quote;
+
+/// Custom derive for `abscissa::config::Config`
+pub fn derive_config(s: synstructure::Structure) -> proc_macro2::TokenStream {
+    s.gen_impl(quote! {
+        gen impl Config for @Self {}
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use synstructure::test_derive;
+
+    #[test]
+    fn derive_config_on_struct() {
+        test_derive! {
+            derive_config {
+                struct MyConfig {
+                    attr: String,
+                }
+            }
+            expands to {
+                #[allow(non_upper_case_globals)]
+                const _DERIVE_Config_FOR_MyConfig: () = {
+                    impl Config for MyConfig {}
+                };
+            }
+            no_build // tests the code compiles are in the `abscissa` crate
+        }
+    }
+}

--- a/abscissa_derive/src/lib.rs
+++ b/abscissa_derive/src/lib.rs
@@ -10,65 +10,12 @@
 
 extern crate proc_macro;
 
-use proc_macro::TokenStream;
-use quote::quote;
+mod command;
+mod config;
+mod runnable;
+
 use synstructure::decl_derive;
 
-/// Custom derive for `abscissa::command::Command`
-#[proc_macro_derive(Command)]
-pub fn derive_command(input: TokenStream) -> TokenStream {
-    let ast: syn::DeriveInput = syn::parse(input).unwrap();
-    let name = &ast.ident;
-    let (impl_generics, ty_generics, where_clause) = ast.generics.split_for_impl();
-
-    let impl_command = quote! {
-        impl #impl_generics Command for #name #ty_generics #where_clause {
-            #[doc = "Name of this program as a string"]
-            fn name() -> &'static str {
-                env!("CARGO_PKG_NAME")
-            }
-
-            #[doc = "Description of this program"]
-            fn description() -> &'static str {
-                env!("CARGO_PKG_DESCRIPTION").trim()
-            }
-
-            #[doc = "Version of this program"]
-            fn version() -> &'static str {
-                env!("CARGO_PKG_VERSION")
-            }
-
-            #[doc = "Authors of this program"]
-            fn authors() -> &'static str {
-                env!("CARGO_PKG_AUTHORS")
-            }
-        }
-    };
-
-    impl_command.into()
-}
-
-/// Custom derive for `abscissa::config::Config`
-fn derive_config(s: synstructure::Structure) -> proc_macro2::TokenStream {
-    s.gen_impl(quote! {
-        gen impl Config for @Self {
-        }
-    })
-}
-decl_derive!([Config] => derive_config);
-
-/// Custom derive for `abscissa::runnable::Runnable`
-fn derive_runnable(s: synstructure::Structure) -> proc_macro2::TokenStream {
-    let body = s.each(|bi| {
-        quote! { #bi.run() }
-    });
-
-    s.gen_impl(quote! {
-        gen impl Runnable for @Self {
-            fn run(&self) {
-                match *self { #body }
-            }
-        }
-    })
-}
-decl_derive!([Runnable] => derive_runnable);
+decl_derive!([Command]  => command::derive_command);
+decl_derive!([Config]   => config::derive_config);
+decl_derive!([Runnable] => runnable::derive_runnable);

--- a/abscissa_derive/src/runnable.rs
+++ b/abscissa_derive/src/runnable.rs
@@ -1,0 +1,62 @@
+use quote::quote;
+
+/// Custom derive for `abscissa::runnable::Runnable`
+pub fn derive_runnable(s: synstructure::Structure) -> proc_macro2::TokenStream {
+    let body = s.each(|bi| {
+        quote! { #bi.run() }
+    });
+
+    s.gen_impl(quote! {
+        gen impl Runnable for @Self {
+            fn run(&self) {
+                match *self { #body }
+            }
+        }
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use synstructure::test_derive;
+
+    #[test]
+    fn derive_runnable_on_enum() {
+        test_derive! {
+            derive_runnable {
+                enum MyRunnable {
+                    A(VariantA),
+                    B(VariantB),
+                    C(VariantC),
+                }
+            }
+            expands to {
+                #[allow(non_upper_case_globals)]
+                const _DERIVE_Runnable_FOR_MyRunnable: () = {
+                    impl Runnable for MyRunnable {
+                        fn run(&self) {
+                            match *self {
+                                MyRunnable::A(ref __binding_0,) => {
+                                    {
+                                        __binding_0.run()
+                                    }
+                                }
+                                MyRunnable::B(ref __binding_0,) => {
+                                    {
+                                        __binding_0.run()
+                                    }
+                                }
+                                MyRunnable::C(ref __binding_0,) => {
+                                    {
+                                        __binding_0.run()
+                                    }
+                                }
+                            }
+                        }
+                    }
+                };
+            }
+            no_build // tests the code compiles are in the `abscissa` crate
+        }
+    }
+}


### PR DESCRIPTION
Adds tests for all proc macros using synstructure's `test_derive!` macro