### PR TITLE
Add app_config()/app_reader()/app_writer() and prelude to template

### DIFF
--- a/abscissa_generator/src/template/collection.rs
+++ b/abscissa_generator/src/template/collection.rs
@@ -30,6 +30,7 @@ const DEFAULT_TEMPLATE_FILES: &[(&str, &str)] = &[
     template!("src/config.rs.hbs"),
     template!("src/error.rs.hbs"),
     template!("src/lib.rs.hbs"),
+    template!("src/prelude.rs.hbs"),
 ];
 
 /// Abscissa application template renderer

--- a/abscissa_generator/template/src/application.rs.hbs
+++ b/abscissa_generator/template/src/application.rs.hbs
@@ -1,13 +1,32 @@
 //! {{title}} Abscissa Application
 
 use crate::{commands::{{~command_type~}}, config::{{~config_type~}}};
-use abscissa::application;
+use abscissa::{application, config};
 use abscissa::{Application, EntryPoint, FrameworkError, LoggingConfig, StandardPaths};
 use lazy_static::lazy_static;
 
 lazy_static! {
     /// Application state
     pub static ref APPLICATION: application::Lock<{{~application_type~}}> = application::Lock::default();
+}
+
+/// Obtain a read-only (multi-reader) lock on the application state.
+///
+/// Panics if the application state has not been initialized.
+pub fn app_reader() -> application::lock::Reader<{{~application_type~}}> {
+    APPLICATION.read()
+}
+
+/// Obtain an exclusive mutable lock on the application state.
+pub fn app_writer() -> application::lock::Writer<{{~application_type~}}> {
+    APPLICATION.write()
+}
+
+/// Obtain a read-only (multi-reader) lock on the application configuration.
+///
+/// Panics if the application configuration has not been loaded.
+pub fn app_config() -> config::Reader<{{~application_type~}}> {
+    config::Reader::new(&APPLICATION)
 }
 
 /// {{title}} Application
@@ -22,9 +41,8 @@ pub struct {{application_type}} {
 
 /// Initialize a new application instance.
 ///
-/// By default no configuration is loaded, and the component set is
-/// empty. Both of these are initialized later in the application
-/// lifecycle by the callbacks below.
+/// By default no configuration is loaded, and the framework state is
+/// initialized to a default, empty state (no components, threads, etc).
 impl Default for {{application_type}} {
     fn default() -> Self {
         Self {

--- a/abscissa_generator/template/src/commands/start.rs.hbs
+++ b/abscissa_generator/template/src/commands/start.rs.hbs
@@ -1,5 +1,10 @@
 //! `start` subcommand - example of how to write a subcommand
 
+/// App-local prelude includes `app_reader()`/`app_writer()`/`app_config()`
+/// accessors along with logging macros. Customize as you see fit.
+#[allow(unused_imports)]
+use crate::prelude::*;
+
 use abscissa::{Command, Options, Runnable};
 
 /// `start` subcommand

--- a/abscissa_generator/template/src/lib.rs.hbs
+++ b/abscissa_generator/template/src/lib.rs.hbs
@@ -16,3 +16,4 @@ pub mod application;
 pub mod commands;
 pub mod config;
 pub mod error;
+pub mod prelude;

--- a/abscissa_generator/template/src/prelude.rs.hbs
+++ b/abscissa_generator/template/src/prelude.rs.hbs
@@ -1,0 +1,11 @@
+//! Application-local prelude: conveniently import types/functions/macros
+//! which are generally useful and should be available everywhere.
+
+/// Application state accessors
+pub use crate::application::{app_config, app_reader, app_writer};
+
+/// Commonly used Abscissa traits
+pub use abscissa::{Application, Command, Runnable};
+
+/// Logging macros
+pub use abscissa::log::{debug, error, info, log, log_enabled, trace, warn};

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,8 +1,10 @@
 //! Support for managing global configuration, as well as loading it from TOML
 
 mod configurable;
+mod merge;
+mod reader;
 
-pub use self::configurable::Configurable;
+pub use self::{configurable::Configurable, merge::MergeOptions, reader::Reader};
 use crate::{
     error::{FrameworkError, FrameworkErrorKind::ConfigError},
     path::AbsPath,

--- a/src/config/merge.rs
+++ b/src/config/merge.rs
@@ -1,7 +1,7 @@
 //! Support for sourcing/overriding configuration values from arguments
 //! given on the command-line.
 
-use crate::options::Options;
+use crate::Options;
 
 /// Merge the given options into this configuration. This allows setting of
 /// global configuration values using command-line options, and also unifies

--- a/src/config/reader.rs
+++ b/src/config/reader.rs
@@ -1,0 +1,39 @@
+//! Mutex guard for immutably accessing global application configuration
+
+use crate::application::{self, Application};
+use std::ops::Deref;
+
+/// Convenience wrapper for `application::lock::Reader` for simplifying
+/// access to global application configuration.
+pub struct Reader<A>(application::lock::Reader<A>)
+where
+    A: 'static + Application;
+
+impl<A> Reader<A>
+where
+    A: 'static + Application,
+{
+    /// Create wrapper around a read-only application mutex guard
+    pub fn new(app_lock: &'static application::Lock<A>) -> Self {
+        Reader(app_lock.read())
+    }
+}
+
+impl<A> Deref for Reader<A>
+where
+    A: 'static + Application,
+{
+    type Target = A::Cfg;
+
+    fn deref(&self) -> &A::Cfg {
+        self.0.config().unwrap_or_else(|| not_loaded())
+    }
+}
+
+/// Error handler called if `get()` is invoked before the global
+/// application config has been loaded.
+///
+/// This indicates a bug in the program accessing this type.
+fn not_loaded() -> ! {
+    panic!("Abscissa application config accessed before it has been initialized!")
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -104,7 +104,7 @@ pub const VERSION: &str = env!("CARGO_PKG_VERSION");
 #[cfg(feature = "logging")]
 #[allow(unused_imports)]
 #[macro_use]
-extern crate log;
+pub extern crate log;
 
 // Load macros first
 #[macro_use]


### PR DESCRIPTION
Adds a set of accessors to the application template:

- `app_config()`: obtain a `config::Reader` for reading app config
- `app_reader()`: obtain a concurrent read-only lock on app state
- `app_writer()`: obtain an exclusive mutable lock on app state

Additionally it adds a `prelude` module to each application which is useful for easily importing common application-specific types/macros.