### PR TITLE
Upgrade to secrecy 0.2; enable serde feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16,7 +16,7 @@ dependencies = [
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.55 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "secrecy 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "secrecy 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
  "signal-hook 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -611,9 +611,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "secrecy"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
+ "serde 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
  "zeroize 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -950,7 +951,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum ryu 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "b96a9549dc8d48f2c283938303c4b5a77aa29bfbc5b54b084fb1630408899a8f"
 "checksum same-file 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "8f20c4be53a8a1ff4c1f1b2bd14570d2f634628709752f0702ecdd2b3f9a5267"
 "checksum scoped_threadpool 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "1d51f5df5af43ab3f1360b429fa5e0152ac5ce8c0bd6485cae490332e96846a8"
-"checksum secrecy 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "436ac345bb6905d8e084df61db85658a263e72f960c1216f2b50d2f3f4cee59e"
+"checksum secrecy 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "89df296e5da94c4df67224ed559b59447d71aca72c7a7269b4e9c2142daa6c0b"
 "checksum semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
 "checksum semver-parser 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 "checksum serde 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)" = "a72e9b96fa45ce22a4bc23da3858dfccfd60acd28a25bcd328a98fdd6bea43fd"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ gumdrop_derive = { version = "0.5", optional = true }
 heck = { version = "0.3", optional = true }
 lazy_static = "1"
 log = { version = "0.4", optional = true }
-secrecy = { version = "0.1", optional = true }
+secrecy = { version = "0.2", optional = true, features = ["serde"] }
 semver = { version = "0.9", optional = true }
 serde = { version = "1", optional = true, features = ["serde_derive"] }
 simplelog = { version = "0.5", optional = true }
@@ -42,7 +42,7 @@ tempfile = "3"
 walkdir = "2"
 
 [features]
-default = ["application", "cli", "signals", "time"]
+default = ["application", "cli", "signals", "secrets", "time"]
 application = ["config", "logging", "options", "semver", "status"]
 cli = ["abscissa_generator", "inflector"]
 config = ["secrets", "serde", "status", "toml"]

--- a/abscissa_generator/src/properties/framework.rs
+++ b/abscissa_generator/src/properties/framework.rs
@@ -7,7 +7,7 @@ pub use semver::Version;
 use serde::{Deserialize, Serialize};
 
 /// Default Cargo features to enable in the `abscissa` crate
-const DEFAULT_CARGO_FEATURES: &[&str] = &["application", "config", "time"];
+const DEFAULT_CARGO_FEATURES: &[&str] = &["application", "signals", "secrets", "time"];
 
 /// Abscissa framework-related properties
 #[derive(Clone, Debug, Deserialize, Serialize)]

--- a/src/config.rs
+++ b/src/config.rs
@@ -11,11 +11,11 @@ use crate::{
 };
 #[doc(hidden)]
 pub use abscissa_derive::Config;
-use serde::{de::DeserializeOwned, Serialize};
+use serde::de::DeserializeOwned;
 use std::{fmt::Debug, fs::File, io::Read};
 
 /// Trait for Abscissa configuration data structures
-pub trait Config: Clone + Debug + DeserializeOwned + Serialize {
+pub trait Config: Debug + DeserializeOwned {
     /// Load the configuration from the given TOML string
     fn load_toml<T: AsRef<str>>(toml_string: T) -> Result<Self, FrameworkError> {
         Ok(toml::from_str(toml_string.as_ref())?)


### PR DESCRIPTION
This upgrades to using secrecy 0.2, and enables the crate's "serde" feature, allowing deserialization of secrets contained in configuration files.

Additionally, it removes the `Clone + Serialize` bounds on configs, as these are not amenable to secrets kept in config files.