### PR TITLE
abscissa_generator: Use Error/ErrorKind names

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,6 +212,12 @@ $ cargo fmt -- --check # generated app is expected to pass rustfmt
 $ cargo clippy
 ```
 
+## Code of Conduct
+
+We abide by the [Contributor Covenant][cc] and ask that you do as well.
+
+For more information, please see [CODE_OF_CONDUCT.md].
+
 ## License
 
 The **abscissa** crate is distributed under the terms of the
@@ -258,6 +264,8 @@ without any additional terms or conditions.
 [cargo]: https://github.com/rust-lang/cargo
 [cargo features]: https://doc.rust-lang.org/cargo/reference/manifest.html#the-features-section
 [Kryptos K2]: https://en.wikipedia.org/wiki/Kryptos#Solution_of_passage_2
+[cc]: https://contributor-covenant.org
+[CODE_OF_CONDUCT.md]: https://github.com/iqlusioninc/abscissa/blob/develop/CODE_OF_CONDUCT.md
 
 [//]: # (crate links)
 

--- a/abscissa_generator/src/properties.rs
+++ b/abscissa_generator/src/properties.rs
@@ -44,10 +44,4 @@ pub struct Properties {
 
     /// Configuration type name
     pub config_type: name::Type,
-
-    /// Error type name
-    pub error_type: name::Type,
-
-    /// Error kind type name
-    pub error_kind_type: name::Type,
 }

--- a/abscissa_generator/src/properties/name.rs
+++ b/abscissa_generator/src/properties/name.rs
@@ -55,6 +55,14 @@ impl AsRef<str> for Type {
 }
 
 impl Type {
+    /// Create a new camel case name
+    pub fn from_camel_case<S>(s: S) -> Type
+    where
+        S: ToString,
+    {
+        Type(s.to_string())
+    }
+
     /// Inflect a snake case name into a type name
     pub fn from_snake_case<S>(s: S) -> Type
     where

--- a/abscissa_generator/template/src/commands.rs.hbs
+++ b/abscissa_generator/template/src/commands.rs.hbs
@@ -30,7 +30,7 @@ pub enum {{command_type}} {
     Version(VersionCommand),
 }
 
-/// This trait allows you to define how applicaiton configuration is loaded.
+/// This trait allows you to define how application configuration is loaded.
 impl Configurable<{{~config_type~}}> for {{command_type}} {
     fn config_path(&self) -> Option<PathBuf> {
         // Have `config_path` return `Some(path)` in order to trigger the

--- a/abscissa_generator/template/src/error.rs.hbs
+++ b/abscissa_generator/template/src/error.rs.hbs
@@ -1,16 +1,16 @@
 //! Error types
 
-use abscissa::{err, Error};
+use abscissa::err;
 use failure::Fail;
 use std::{fmt, io};
 
 /// Error type
 #[derive(Debug)]
-pub struct {{error_type}}(Error<{{error_kind_type}}>);
+pub struct Error(abscissa::Error<ErrorKind>);
 
 /// Kinds of errors
 #[derive(Copy, Clone, Eq, PartialEq, Debug, Fail)]
-pub enum {{error_kind_type}} {
+pub enum ErrorKind {
     /// Error in configuration file
     #[fail(display = "config error")]
     Config,
@@ -20,20 +20,20 @@ pub enum {{error_kind_type}} {
     Io,
 }
 
-impl fmt::Display for {{error_type}} {
+impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.0.fmt(f)
     }
 }
 
-impl From<Error<{{error_kind_type}}>> for {{error_type}} {
-    fn from(other: Error<{{error_kind_type}}>) -> Self {
-        {{error_type}}(other)
+impl From<abscissa::Error<ErrorKind>> for Error {
+    fn from(other: abscissa::Error<ErrorKind>) -> Self {
+        Error(other)
     }
 }
 
-impl From<io::Error> for {{error_type}} {
+impl From<io::Error> for Error {
     fn from(other: io::Error) -> Self {
-        err!({{error_kind_type}}::Io, other).into()
+        err!(ErrorKind::Io, other).into()
     }
 }

--- a/src/bin/abscissa/commands/new.rs
+++ b/src/bin/abscissa/commands/new.rs
@@ -156,13 +156,6 @@ impl NewCommand {
         // TODO(tarcieri): configurable config type
         let config_type = properties::name::Type::from_snake_case(app_name.clone() + "_config");
 
-        // TODO(tarcieri): configurable error type
-        let error_type = properties::name::Type::from_snake_case(app_name.clone() + "_error");
-
-        // TODO(tarcieri): configurable error kind type
-        let error_kind_type =
-            properties::name::Type::from_snake_case(app_name.clone() + "_error_kind");
-
         let properties = Properties {
             abscissa,
             name,
@@ -175,8 +168,6 @@ impl NewCommand {
             application_type,
             command_type,
             config_type,
-            error_type,
-            error_kind_type,
         };
 
         Ok(properties)


### PR DESCRIPTION
...instead of a custom per-app error type. This is shorter and more convenient.