### PR TITLE
Command usage improvements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,6 +30,7 @@ dependencies = [
 name = "abscissa_derive"
 version = "0.1.0-pre.1"
 dependencies = [
+ "heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 0.15.34 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/abscissa_derive/Cargo.toml
+++ b/abscissa_derive/Cargo.toml
@@ -16,6 +16,7 @@ circle-ci = { repository = "iqlusioninc/abscissa", branch = "develop" }
 proc-macro = true
 
 [dependencies]
+heck = "0.3"
 proc-macro2 = "0.4"
 quote = "0.6"
 syn = "0.15"

--- a/abscissa_derive/src/command.rs
+++ b/abscissa_derive/src/command.rs
@@ -1,7 +1,17 @@
+//! Custom derive support for `abscissa::command::Command`.
+
+use heck::KebabCase;
+use proc_macro2::TokenStream;
 use quote::quote;
+use synstructure::Structure;
 
 /// Custom derive for `abscissa::command::Command`
-pub fn derive_command(s: synstructure::Structure) -> proc_macro2::TokenStream {
+pub fn derive_command(s: Structure) -> TokenStream {
+    let subcommand_usage = match &s.ast().data {
+        syn::Data::Enum(data) => impl_subcommand_usage_for_enum(data),
+        _ => quote!(),
+    };
+
     s.gen_impl(quote! {
         gen impl Command for @Self {
             #[doc = "Name of this program as a string"]
@@ -23,8 +33,47 @@ pub fn derive_command(s: synstructure::Structure) -> proc_macro2::TokenStream {
             fn authors() -> &'static str {
                 env!("CARGO_PKG_AUTHORS")
             }
+
+            #subcommand_usage
         }
     })
+}
+
+/// Impl `subcommand_usage` which walks the enum variants and returns
+/// usage info for them.
+fn impl_subcommand_usage_for_enum(data: &syn::DataEnum) -> TokenStream {
+    let match_arms = data.variants.iter().map(|variant| {
+        // TODO(tarcieri): support `#[options(name = "...")]` attribute
+        let name = variant.ident.to_string().to_kebab_case();
+
+        let subcommand = match &variant.fields {
+            syn::Fields::Unnamed(fields) => {
+                if fields.unnamed.len() == 1 {
+                    Some(&fields.unnamed.first().unwrap().into_value().ty)
+                } else {
+                    None
+                }
+            }
+            syn::Fields::Unit | syn::Fields::Named(_) => None,
+        }
+        .unwrap_or_else(|| panic!("command variants must be unary tuples"));
+
+        quote! {
+            #name => {
+                Some(abscissa::command::Usage::for_command::<#subcommand>())
+            }
+        }
+    });
+
+    quote! {
+        #[doc = "get usage information for the named subcommand"]
+        fn subcommand_usage(command: &str) -> Option<abscissa::command::Usage> {
+            match command {
+                #(#match_arms)*
+                _ => None
+            }
+        }
+    }
 }
 
 #[cfg(test)]
@@ -60,6 +109,62 @@ mod tests {
                         #[doc = "Authors of this program"]
                         fn authors() -> & 'static str {
                             env!("CARGO_PKG_AUTHORS")
+                        }
+                    }
+                };
+            }
+            no_build // tests the code compiles are in the `abscissa` crate
+        }
+    }
+
+    #[test]
+    fn derive_command_on_enum() {
+        test_derive! {
+            derive_command {
+                enum MyCommand {
+                    Foo(A),
+                    Bar(B),
+                    Baz(C),
+                }
+            }
+            expands to {
+                #[allow(non_upper_case_globals)]
+                const _DERIVE_Command_FOR_MyCommand: () = {
+                    impl Command for MyCommand {
+                        #[doc = "Name of this program as a string"]
+                        fn name() -> & 'static str {
+                            env!("CARGO_PKG_NAME")
+                        }
+
+                        #[doc = "Description of this program"]
+                        fn description () -> & 'static str {
+                            env!("CARGO_PKG_DESCRIPTION" ).trim()
+                        }
+
+                        #[doc = "Version of this program"]
+                        fn version() -> & 'static str {
+                            env!( "CARGO_PKG_VERSION")
+                        }
+
+                        #[doc = "Authors of this program"]
+                        fn authors() -> & 'static str {
+                            env!("CARGO_PKG_AUTHORS")
+                        }
+
+                        #[doc = "get usage information for the named subcommand"]
+                        fn subcommand_usage(command: &str) -> Option <abscissa::command::Usage > {
+                            match command {
+                                "foo" => {
+                                    Some(abscissa::command::Usage::for_command::<A>())
+                                }
+                                "bar" => {
+                                    Some(abscissa::command::Usage::for_command::<B>())
+                                }
+                                "baz" => {
+                                    Some(abscissa::command::Usage::for_command::<C>())
+                                }
+                                _ => None
+                            }
                         }
                     }
                 };

--- a/abscissa_derive/src/runnable.rs
+++ b/abscissa_derive/src/runnable.rs
@@ -37,19 +37,13 @@ mod tests {
                         fn run(&self) {
                             match *self {
                                 MyRunnable::A(ref __binding_0,) => {
-                                    {
-                                        __binding_0.run()
-                                    }
+                                    { __binding_0.run() }
                                 }
                                 MyRunnable::B(ref __binding_0,) => {
-                                    {
-                                        __binding_0.run()
-                                    }
+                                    { __binding_0.run() }
                                 }
                                 MyRunnable::C(ref __binding_0,) => {
-                                    {
-                                        __binding_0.run()
-                                    }
+                                    { __binding_0.run() }
                                 }
                             }
                         }

--- a/abscissa_generator/template/src/commands.rs.hbs
+++ b/abscissa_generator/template/src/commands.rs.hbs
@@ -15,12 +15,16 @@ mod version;
 
 use self::{start::StartCommand, version::VersionCommand};
 use crate::config::{{~config_type~}};
-use abscissa::{Command, Configurable, Options, Runnable};
+use abscissa::{Command, Configurable, Help, Options, Runnable};
 use std::path::PathBuf;
 
 /// {{title}} Subcommands
 #[derive(Command, Debug, Options, Runnable)]
 pub enum {{command_type}} {
+    /// The `help` subcommand
+    #[options(help = "get usage information")]
+    Help(Help<Self>),
+
     /// The `start` subcommand
     #[options(help = "start the application")]
     Start(StartCommand),

--- a/abscissa_generator/template/src/commands/start.rs.hbs
+++ b/abscissa_generator/template/src/commands/start.rs.hbs
@@ -26,7 +26,7 @@ impl Runnable for StartCommand {
     fn run(&self) {
         match &self.recipient {
             Some(recipient) => println!("Hello, {}!", recipient),
-            None => Self::print_usage(&[]),
+            None => println!("Hello, world!"),
         }
     }
 }

--- a/abscissa_generator/template/src/commands/version.rs.hbs
+++ b/abscissa_generator/template/src/commands/version.rs.hbs
@@ -2,15 +2,20 @@
 
 #![allow(clippy::never_loop)]
 
+use super::{{~command_type~}};
 use abscissa::{Command, Options, Runnable};
 
 /// `version` subcommand
-#[derive(Debug, Default, Options)]
+#[derive(Command, Debug, Default, Options)]
 pub struct VersionCommand {}
 
 impl Runnable for VersionCommand {
     /// Print version message
     fn run(&self) {
-        super::{{~command_type~}}::print_package_info();
+        println!(
+            "{} {}",
+            {{command_type~}}::name(),
+            {{command_type~}}::version()
+        );
     }
 }

--- a/src/bin/abscissa/commands/version.rs
+++ b/src/bin/abscissa/commands/version.rs
@@ -2,15 +2,16 @@
 
 #![allow(clippy::never_loop)]
 
+use super::CliCommand;
 use abscissa::{Command, Options, Runnable};
 
 /// `version` subcommand
-#[derive(Debug, Default, Options)]
+#[derive(Command, Debug, Default, Options)]
 pub struct VersionCommand {}
 
 impl Runnable for VersionCommand {
     /// Print version message
     fn run(&self) {
-        super::CliCommand::print_package_info();
+        println!("{} {}", CliCommand::name(), CliCommand::version());
     }
 }

--- a/src/command/entrypoint.rs
+++ b/src/command/entrypoint.rs
@@ -1,6 +1,7 @@
 //! Toplevel entrypoint command.
 
-use crate::{Command, Config, Configurable, Options, Runnable};
+use super::Command;
+use crate::{Config, Configurable, Options, Runnable};
 use std::path::PathBuf;
 
 /// Toplevel entrypoint command.
@@ -17,7 +18,7 @@ pub struct EntryPoint<Cmd: Runnable + Command> {
     pub help: bool,
 
     /// Increase verbosity setting
-    #[options(help = "be verbose")]
+    #[options(short = "v", help = "be verbose")]
     pub verbose: bool,
 
     /// Subcommand to execute.
@@ -36,7 +37,7 @@ where
     fn command(&self) -> &Cmd {
         self.command
             .as_ref()
-            .unwrap_or_else(|| Cmd::print_usage(&[]))
+            .unwrap_or_else(|| Cmd::print_usage_and_exit(&[]))
     }
 }
 

--- a/src/command/help.rs
+++ b/src/command/help.rs
@@ -1,0 +1,87 @@
+//! Help command
+
+use super::Command;
+use crate::runnable::Runnable;
+use gumdrop::{Error, Opt, Options, Parser};
+use std::marker::PhantomData;
+
+/// Help command which prints usage information.
+///
+/// Generic over `Command` types.
+#[derive(Debug, Default)]
+pub struct Help<C: Command> {
+    /// Obtain help for a particular subcommand
+    pub opts: Vec<String>,
+
+    /// Command for which to obtain usage information
+    command: PhantomData<C>,
+}
+
+impl<C> Command for Help<C>
+where
+    C: Command,
+{
+    fn name() -> &'static str {
+        C::name()
+    }
+
+    fn description() -> &'static str {
+        C::description()
+    }
+
+    fn version() -> &'static str {
+        C::version()
+    }
+
+    fn authors() -> &'static str {
+        C::authors()
+    }
+}
+
+impl<C> Options for Help<C>
+where
+    C: Command,
+{
+    fn parse<S: AsRef<str>>(parser: &mut Parser<S>) -> Result<Self, Error> {
+        let mut opts = vec![];
+
+        while let Some(opt) = parser.next_opt() {
+            match opt {
+                Opt::Free(free_opt) => opts.push(free_opt.to_owned()),
+                _ => return Err(Error::unexpected_argument(opt)),
+            }
+        }
+
+        Ok(Self {
+            opts,
+            command: PhantomData,
+        })
+    }
+
+    fn parse_command<S: AsRef<str>>(_name: &str, parser: &mut Parser<S>) -> Result<Self, Error> {
+        // TODO(tarcieri): is this necessary or the best approach?
+        Self::parse(parser)
+    }
+
+    fn usage() -> &'static str {
+        ""
+    }
+
+    fn command_usage(_command: &str) -> Option<&'static str> {
+        None
+    }
+
+    fn command_list() -> Option<&'static str> {
+        None
+    }
+}
+
+impl<C> Runnable for Help<C>
+where
+    C: Command,
+{
+    /// Print help information for the given command
+    fn run(&self) {
+        C::print_usage_and_exit(&self.opts);
+    }
+}

--- a/src/command/usage.rs
+++ b/src/command/usage.rs
@@ -1,0 +1,427 @@
+//! Usage information presenter
+
+use super::Command;
+use crate::{terminal::stream::STDOUT, Version};
+use std::{
+    io::{self, Write},
+    process,
+};
+use termcolor::{Color, ColorSpec, WriteColor};
+
+/// Presenter for usage information for a particular `Command`
+#[derive(Debug)]
+pub struct Usage {
+    /// Package name
+    pub package_name: String,
+
+    /// Package version
+    pub package_version: Version,
+
+    /// Package authors
+    pub package_authors: Vec<String>,
+
+    /// Package description
+    pub package_description: Option<String>,
+
+    /// Command-line options
+    pub args: Vec<Argument>,
+
+    /// Subcommands
+    pub subcommands: Vec<Subcommand>,
+}
+
+impl Usage {
+    /// Build usage information for a particular command
+    pub fn for_command<C>() -> Self
+    where
+        C: Command,
+    {
+        let package_name = C::name().to_owned();
+        let package_version = Version::parse(C::version()).expect("invalid version");
+        let package_authors = C::authors().split(':').map(String::from).collect();
+
+        let package_description = C::description()
+            .split_whitespace()
+            .collect::<Vec<_>>()
+            .join(" ");
+
+        let args = C::usage()
+            .split('\n')
+            .filter_map(Argument::parse_usage)
+            .collect();
+
+        let subcommands = C::command_list()
+            .map(|command_list| {
+                command_list
+                    .split('\n')
+                    .map(|usage| Subcommand::parse_usage::<C>(usage))
+                    .collect()
+            })
+            .unwrap_or_else(|| vec![]);
+
+        Self {
+            package_name,
+            package_version,
+            package_authors,
+            package_description: if package_description.is_empty() {
+                None
+            } else {
+                Some(package_description)
+            },
+            args,
+            subcommands,
+        }
+    }
+
+    /// Print usage for a particular subcommand
+    pub fn print_subcommand(&self, args: &[String]) -> Result<(), io::Error> {
+        let mut stdout = STDOUT.lock();
+        stdout.reset()?;
+
+        let mut recognized = vec![];
+        let mut cmd = self;
+        let mut description = None;
+
+        for arg in args {
+            match cmd.subcommands.iter().find(|cmd| cmd.name == args[0]) {
+                Some(subcommand) => {
+                    recognized.push(arg.clone());
+                    description = Some(&subcommand.description);
+                    cmd = &subcommand.usage;
+                }
+                None => {
+                    cmd.print_unrecognized_command(arg, &recognized)?;
+
+                    // Force error status exit code
+                    return Err(io::ErrorKind::NotFound.into());
+                }
+            }
+        }
+
+        cmd.print_info()?;
+
+        let mut white = ColorSpec::new();
+        white.set_fg(Some(Color::White));
+        white.set_bold(true);
+
+        stdout.set_color(&white)?;
+        writeln!(stdout, "USAGE:")?;
+        stdout.reset()?;
+
+        let mut usage_items = vec![self.package_name.clone()];
+        usage_items.extend(recognized.iter().map(|s| s.to_string()));
+        let usage_string = usage_items.join(" ");
+
+        if cmd.subcommands.is_empty() {
+            writeln!(stdout, "    {} <OPTIONS>", &usage_string)?;
+        } else {
+            writeln!(stdout, "    {} <SUBCOMMAND>", &usage_string)?;
+        }
+
+        writeln!(stdout)?;
+
+        if let Some(desc) = description {
+            stdout.set_color(&white)?;
+            writeln!(stdout, "DESCRIPTION:")?;
+            stdout.reset()?;
+
+            writeln!(stdout, "    {}", desc)?;
+            writeln!(stdout)?;
+        }
+
+        cmd.print_usage()
+    }
+
+    /// Print usage for a particular subcommand and exit
+    pub fn print_subcommand_and_exit(&self, args: &[String]) -> ! {
+        let exit_code = match self.print_subcommand(args) {
+            Ok(_) => 0,
+            Err(_) => 1,
+        };
+
+        process::exit(exit_code);
+    }
+
+    /// Print information about a usage error
+    pub(super) fn print_error_and_exit(&self, err: gumdrop::Error, _args: &[String]) -> ! {
+        // TODO(tarcieri): introspect args and print a better message
+        let mut stdout = STDOUT.lock();
+        stdout.reset().unwrap();
+
+        let mut red = ColorSpec::new();
+        red.set_fg(Some(Color::Red));
+        red.set_bold(true);
+
+        stdout.set_color(&red).unwrap();
+        write!(stdout, "error: ").unwrap();
+        stdout.reset().unwrap();
+
+        writeln!(stdout, "{}", err).unwrap();
+        writeln!(stdout).unwrap();
+
+        self.print_usage().unwrap();
+        process::exit(1);
+    }
+
+    /// Print information about an unrecognized command
+    fn print_unrecognized_command(
+        &self,
+        unrecognized: &str,
+        recognized: &[String],
+    ) -> Result<(), io::Error> {
+        let mut stdout = STDOUT.lock();
+        stdout.reset().unwrap();
+
+        let mut unrecognized_items = recognized.iter().map(|s| s.to_string()).collect::<Vec<_>>();
+        unrecognized_items.push(unrecognized.to_owned());
+
+        let unrecognized_string = unrecognized_items.join(" ");
+
+        let mut red = ColorSpec::new();
+        red.set_fg(Some(Color::Red));
+        red.set_bold(true);
+
+        let mut yellow = ColorSpec::new();
+        yellow.set_fg(Some(Color::Yellow));
+        yellow.set_bold(true);
+
+        let mut green = ColorSpec::new();
+        green.set_fg(Some(Color::Green));
+        green.set_bold(true);
+
+        stdout.set_color(&red)?;
+        write!(stdout, "error: ")?;
+        stdout.reset()?;
+
+        write!(stdout, "The subcommand ")?;
+
+        stdout.set_color(&yellow)?;
+        write!(stdout, "{:?} ", &unrecognized_string)?;
+        stdout.reset()?;
+
+        writeln!(stdout, "wasn't recognized.")?;
+        writeln!(stdout)?;
+
+        let mut white = ColorSpec::new();
+        white.set_fg(Some(Color::White));
+        white.set_bold(true);
+
+        stdout.set_color(&yellow)?;
+        writeln!(stdout, "USAGE:")?;
+        stdout.reset()?;
+
+        if self.subcommands.is_empty() {
+            writeln!(stdout, "    {} <OPTIONS>", recognized.join(" "))?;
+        } else {
+            writeln!(stdout, "    {} <SUBCOMMAND>", recognized.join(" "))?;
+        }
+
+        writeln!(stdout)?;
+        self.print_usage()
+    }
+
+    /// Print program and usage information
+    pub fn print_info(&self) -> Result<(), io::Error> {
+        let mut stdout = STDOUT.lock();
+        stdout.reset()?;
+
+        let mut white = ColorSpec::new();
+        white.set_fg(Some(Color::White));
+        white.set_bold(true);
+
+        stdout.set_color(&white)?;
+        writeln!(stdout, "{} {}", &self.package_name, &self.package_version)?;
+        stdout.reset()?;
+
+        if !self.package_authors.is_empty() {
+            writeln!(stdout, "{}", self.package_authors.join(", "))?;
+        }
+
+        if let Some(ref description) = self.package_description {
+            writeln!(stdout, "{}", description)?;
+        }
+
+        writeln!(stdout)?;
+        Ok(())
+    }
+
+    /// Print usage information only
+    pub fn print_usage(&self) -> Result<(), io::Error> {
+        let mut stdout = STDOUT.lock();
+
+        let mut white = ColorSpec::new();
+        white.set_fg(Some(Color::White));
+        white.set_bold(true);
+
+        if !self.args.is_empty() {
+            stdout.set_color(&white)?;
+            writeln!(stdout, "FLAGS:")?;
+            stdout.reset()?;
+
+            for arg in &self.args {
+                arg.print(&mut stdout)?;
+            }
+
+            writeln!(stdout)?;
+        }
+
+        if !self.subcommands.is_empty() {
+            stdout.set_color(&white)?;
+            writeln!(stdout, "SUBCOMMANDS:")?;
+            stdout.reset()?;
+
+            for command in &self.subcommands {
+                command.print_brief(&mut stdout)?;
+            }
+        }
+
+        Ok(())
+    }
+}
+
+/// Presenter for flags/options
+#[derive(Debug)]
+pub struct Argument {
+    /// Short name (one char)
+    pub short: Option<char>,
+
+    /// Long name
+    pub long: Option<String>,
+
+    /// Long param
+    pub long_param: Option<String>,
+
+    /// Description
+    pub description: Option<String>,
+}
+
+impl Argument {
+    /// Parse flags from `gumdrop` usage string.
+    // TODO(tarcieri): less hacky approach
+    fn parse_usage(usage: &str) -> Option<Self> {
+        let words = usage.split_whitespace().collect::<Vec<_>>();
+
+        if words.is_empty() {
+            return None;
+        }
+
+        let mut arg = Self {
+            short: None,
+            long: None,
+            long_param: None,
+            description: None,
+        };
+
+        if words[0].starts_with('-') && !words[0].starts_with("--") {
+            arg.short = Some(words[0].chars().nth(1).expect("truncated short arg"));
+            arg.parse_long_arg(&words[1..]);
+        } else {
+            arg.parse_long_arg(&words);
+        }
+
+        if arg.short.is_some() || arg.long.is_some() {
+            Some(arg)
+        } else {
+            None
+        }
+    }
+
+    /// Parse the long form argument and description
+    fn parse_long_arg(&mut self, usage: &[&str]) {
+        if usage.is_empty() {
+            return;
+        }
+
+        let word = usage[0];
+
+        if word.starts_with("--") {
+            if usage.len() < 2 {
+                return;
+            }
+
+            self.long = Some(word[2..].to_owned());
+
+            if usage[1].chars().all(|c| c.is_uppercase() || c == '-') {
+                self.long_param = Some(usage[1].to_owned());
+                self.parse_description(&usage[2..]);
+            } else {
+                self.parse_description(&usage[1..])
+            }
+        } else {
+            self.parse_description(usage)
+        }
+    }
+
+    /// Parse description
+    fn parse_description(&mut self, usage: &[&str]) {
+        if !usage.is_empty() {
+            self.description = Some(usage.join(" "));
+        }
+    }
+
+    /// Print the argument to the given I/O stream
+    fn print(&self, stream: &mut impl Write) -> Result<(), io::Error> {
+        let mut arg_str = String::new();
+
+        if let Some(short) = self.short {
+            arg_str.push('-');
+            arg_str.push(short);
+
+            if self.long.is_some() {
+                arg_str.push_str(", ");
+            }
+        }
+
+        if let Some(ref long) = self.long {
+            arg_str.push_str("--");
+            arg_str.push_str(long);
+
+            if let Some(ref param) = self.long_param {
+                arg_str.push(' ');
+                arg_str.push_str(param);
+            }
+        }
+
+        let description = self.description.as_ref().map(String::as_str).unwrap_or("");
+        writeln!(stream, "    {:<25} {}", &arg_str, description)
+    }
+}
+
+/// Presenter for subcommands
+#[derive(Debug)]
+pub struct Subcommand {
+    /// Subcommand name
+    pub name: String,
+
+    /// Subcommand description
+    pub description: String,
+
+    /// Subcommand usage
+    pub usage: Usage,
+}
+
+impl Subcommand {
+    /// Parse usage information for a particular subcommand
+    // TODO(tarcieri): less hacky approach
+    fn parse_usage<C>(usage_string: &str) -> Self
+    where
+        C: Command,
+    {
+        let words = usage_string.split_whitespace().collect::<Vec<_>>();
+        let name = words[0].to_owned();
+        let description = words[1..].join(" ");
+        let usage = C::subcommand_usage(&name)
+            .unwrap_or_else(|| panic!("error fetching usage for subcommand: {:?}", name));
+
+        Self {
+            name,
+            description,
+            usage,
+        }
+    }
+
+    /// Print the subcommand to the given I/O stream
+    fn print_brief(&self, stream: &mut impl Write) -> Result<(), io::Error> {
+        writeln!(stream, "    {:<10} {}", &self.name, &self.description)
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -118,7 +118,7 @@ pub mod terminal;
 #[cfg(feature = "application")]
 pub mod application;
 #[cfg(feature = "options")]
-mod command;
+pub mod command;
 #[cfg(feature = "application")]
 pub mod component;
 #[cfg(feature = "config")]
@@ -158,7 +158,7 @@ pub use crate::{
 };
 #[cfg(feature = "options")]
 pub use crate::{
-    command::{Command, EntryPoint},
+    command::{Command, EntryPoint, Help},
     path::StandardPaths,
 };
 

--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -7,3 +7,12 @@ pub mod status;
 pub(crate) mod stream;
 
 pub use termcolor::{Color, ColorChoice};
+
+/// Initialize the terminal subsystem manually, using automatic color
+/// detection.
+///
+/// This is useful when Abscissa internally leverages the terminal subsystem
+/// without booting a full application, such as displaying usage information.
+pub(crate) fn init() {
+    self::component::TerminalComponent::new(ColorChoice::Auto);
+}

--- a/tests/generate_app.rs
+++ b/tests/generate_app.rs
@@ -12,7 +12,7 @@ const APP_NAME: &str = "generated_test_app";
 const TEST_COMMANDS: &[&str] = &[
     "fmt -- --check",
     "test --release",
-    "run -- --version",
+    "run -- version",
     "clippy",
 ];
 


### PR DESCRIPTION
Adds a `termcolor`-powered presenter for displaying usage information for commands.

Supports nested subcommands of unbounded depth.

Additionally adds `abscissa::command::Help` which provides a generic help command usable with any parent `Command`, and uses it in the default template.