### PR TITLE
testing: Add initial testing subsystem

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6,9 +6,8 @@ version = "0.1.0-pre.2"
 dependencies = [
  "abscissa_derive 0.1.0-pre.2",
  "abscissa_generator 0.1.0-pre.2",
- "atty 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "canonical-path 2.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "chrono 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "gumdrop 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "gumdrop_derive 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -23,7 +22,7 @@ dependencies = [
  "tempfile 3.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "termcolor 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "walkdir 2.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wait-timeout 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -64,16 +63,6 @@ version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "atty"
-version = "0.2.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "libc 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
- "termion 1.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "autocfg"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -112,7 +101,7 @@ dependencies = [
  "block-padding 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "byte-tools 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "generic-array 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "generic-array 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -150,9 +139,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "chrono"
-version = "0.4.6"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
+ "libc 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-integer 0.1.41 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.93 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -172,7 +162,7 @@ name = "digest"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "generic-array 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "generic-array 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -207,7 +197,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "generic-array"
-version = "0.12.0"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "typenum 1.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -313,11 +303,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "autocfg 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
-
-[[package]]
-name = "numtoa"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "opaque-debug"
@@ -494,14 +479,6 @@ version = "0.1.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "redox_termios"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "redox_syscall 0.1.54 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "regex"
 version = "1.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -670,17 +647,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "termion"
-version = "1.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "libc 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
- "numtoa 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "redox_syscall 0.1.54 (registry+https://github.com/rust-lang/crates.io-index)",
- "redox_termios 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "thread_local"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -737,6 +703,14 @@ version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "wait-timeout"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "walkdir"
 version = "2.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -790,7 +764,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [metadata]
 "checksum aho-corasick 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)" = "e6f484ae0c99fec2e858eb6134949117399f222608d84cadb3f58c1f97c2364c"
 "checksum arc-swap 0.3.11 (registry+https://github.com/rust-lang/crates.io-index)" = "bc4662175ead9cd84451d5c35070517777949a2ed84551764129cedb88384841"
-"checksum atty 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "9a7d5b8723950951411ee34d271d99dddcc2035a16ab25310ea2c8cfd4369652"
 "checksum autocfg 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "0e49efa51329a5fd37e7c79db4621af617cd4e3e5bc224939808d076077077bf"
 "checksum backtrace 0.3.31 (registry+https://github.com/rust-lang/crates.io-index)" = "e0f77aa27f55a4beb477ff6bc4d9bf72f90eb422b19c1d8e5a644b8aeb674d66"
 "checksum backtrace-sys 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)" = "797c830ac25ccc92a7f8a7b9862bde440715531514594a6154e3d4a54dd769b6"
@@ -802,14 +775,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum canonical-path 2.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e6e9e01327e6c86e92ec72b1c798d4a94810f147209bbe3ffab6a86954937a6f"
 "checksum cc 1.0.37 (registry+https://github.com/rust-lang/crates.io-index)" = "39f75544d7bbaf57560d2168f28fd649ff9c76153874db88bdbdfd839b1a7e7d"
 "checksum cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "b486ce3ccf7ffd79fdeb678eac06a9e6c09fc88d33836340becb8fffe87c5e33"
-"checksum chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "45912881121cb26fad7c38c17ba7daa18764771836b34fab7d3fbd93ed633878"
+"checksum chrono 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)" = "77d81f58b7301084de3b958691458a53c3f7e0b1d702f77e550b6a88e3a88abe"
 "checksum cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
 "checksum digest 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "05f47366984d3ad862010e22c7ce81a7dbcaebbdfb37241a620f8b6596ee135c"
 "checksum failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "795bd83d3abeb9220f257e597aa0080a508b27533824adf336529648f6abf7e2"
 "checksum failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "ea1063915fd7ef4309e222a5a07cf9c319fb9c7836b1f89b85458672dbb127e1"
 "checksum fake-simd 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e88a8acf291dafb59c2d96e8f59828f3838bb1a70398823ade51a84de6a6deed"
 "checksum fuchsia-cprng 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
-"checksum generic-array 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3c0f28c2f5bfb5960175af447a2da7c18900693738343dc896ffbcabd9839592"
+"checksum generic-array 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)" = "c68f0274ae0e023facc3c97b2e00f076be70e254bc851d972503b328db79b2ec"
 "checksum gumdrop 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7a57b4113bb9af093a1cd0b505a44a93103e32e258296d01fa2def3f37c2c7cc"
 "checksum gumdrop_derive 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "dae5488e2c090f7586e2027e4ea6fcf8c9d83e2ef64d623993a33a0fb811f1f7"
 "checksum handlebars 2.0.0-beta.3 (registry+https://github.com/rust-lang/crates.io-index)" = "20a07631e0626b356ea6149a7f1824b32926d7c74e2be4555423c1d6414bebbb"
@@ -823,7 +796,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum memchr 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2efc7bc57c883d4a4d6e3246905283d8dae951bb3bd32f49d6ef297f546e1c39"
 "checksum num-integer 0.1.41 (registry+https://github.com/rust-lang/crates.io-index)" = "b85e541ef8255f6cf42bbfe4ef361305c6c135d10919ecc26126c4e5ae94bc09"
 "checksum num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "6ba9a427cfca2be13aa6f6403b0b7e7368fe982bfa16fccc450ce74c46cd9b32"
-"checksum numtoa 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b8f8bdf33df195859076e54ab11ee78a1b208382d3a26ec40d142ffc1ecc49ef"
 "checksum opaque-debug 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "93f5bb2e8e8dec81642920ccff6b61f1eb94fa3020c5a325c9851ff604152409"
 "checksum pest 2.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "933085deae3f32071f135d799d75667b63c8dc1f4537159756e3d4ceab41868c"
 "checksum pest_derive 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "833d1ae558dc601e9a60366421196a8d94bc0ac980476d0b67e1d0988d72b2d0"
@@ -844,7 +816,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum rand_xorshift 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "cbf7e9e623549b0e21f6e97cf8ecf247c1a8fd2e8a992ae265314300b2455d5c"
 "checksum rdrand 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
 "checksum redox_syscall 0.1.54 (registry+https://github.com/rust-lang/crates.io-index)" = "12229c14a0f65c4f1cb046a3b52047cdd9da1f4b30f8a39c5063c8bae515e252"
-"checksum redox_termios 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7e891cfe48e9100a70a3b6eb652fef28920c117d366339687bd5576160db0f76"
 "checksum regex 1.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "0b2f0808e7d7e4fb1cb07feb6ff2f4bc827938f24f8c2e6a3beb7370af544bdd"
 "checksum regex-syntax 0.6.7 (registry+https://github.com/rust-lang/crates.io-index)" = "9d76410686f9e3a17f06128962e0ecc5755870bb890c34820c7af7f1db2e1d48"
 "checksum remove_dir_all 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "4a83fa3702a688b9359eccba92d153ac33fd2e8462f9e0e3fdf155239ea7792e"
@@ -864,7 +835,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum synstructure 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)" = "02353edf96d6e4dc81aea2d8490a7e9db177bf8acb0e951c24940bf866cb313f"
 "checksum tempfile 3.0.8 (registry+https://github.com/rust-lang/crates.io-index)" = "7dc4738f2e68ed2855de5ac9cdbe05c9216773ecde4739b2f095002ab03a13ef"
 "checksum termcolor 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "96d6098003bde162e4277c70665bd87c326f5a0c3f3fbfb285787fa482d54e6e"
-"checksum termion 1.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "6a8fb22f7cde82c8220e5aeacb3258ed7ce996142c77cba193f203515e26c330"
 "checksum thread_local 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c6b53e329000edc2b34dbe8545fd20e55a333362d0a321909685a19bd28c3f1b"
 "checksum time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)" = "db8dcfca086c1143c9270ac42a2bbd8a7ee477b78ac8e45b19abfb0cbede4b6f"
 "checksum toml 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b8c96d7873fa7ef8bdeb3a9cda3ac48389b4154f32b9803b4bc26220b677b039"
@@ -874,6 +844,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum unicode-segmentation 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1967f4cdfc355b37fd76d2a954fb2ed3871034eb4f26d60537d88795cfc332a9"
 "checksum unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
 "checksum utf8-ranges 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "9d50aa7650df78abf942826607c62468ce18d9019673d4a2ebe1865dbb96ffde"
+"checksum wait-timeout 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9f200f5b12eb75f8c1ed65abd4b2db8a6e1b138a20de009dacee265a2498f3f6"
 "checksum walkdir 2.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "c7904a7e2bb3cdf0cf5e783f44204a85a37a93151738fa349f06680f59a98b45"
 "checksum winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)" = "f10e386af2b13e47c89e7236a7a14a086791a2b88ebad6df9bf42040195cf770"
 "checksum winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,18 +30,17 @@ semver = { version = "0.9", optional = true }
 serde = { version = "1", optional = true, features = ["serde_derive"] }
 termcolor = { version = "1", optional = true }
 toml = { version = "0.5", optional = true }
+wait-timeout = { version = "0.2", optional = true }
 
 [target.'cfg(unix)'.dependencies]
 libc = { version = "0.2", optional = true }
 signal-hook = { version = "0.1", optional = true }
 
 [dev-dependencies]
-atty = "0.2"
 tempfile = "3"
-walkdir = "2"
 
 [features]
-default = ["application", "cli", "signals", "secrets", "time"]
+default = ["application", "cli", "signals", "secrets", "testing", "time"]
 application = ["config", "logging", "options", "semver", "terminal"]
 cli = ["abscissa_generator", "inflector"]
 config = ["secrets", "serde", "terminal", "toml"]
@@ -51,6 +50,7 @@ options = ["gumdrop", "gumdrop_derive"]
 secrets = ["secrecy"]
 signals = ["libc", "signal-hook"]
 terminal = ["termcolor"]
+testing = ["wait-timeout"]
 time = ["chrono"]
 
 [badges]

--- a/abscissa_generator/template/Cargo.toml.hbs
+++ b/abscissa_generator/template/Cargo.toml.hbs
@@ -18,6 +18,9 @@ features = [{{~#each abscissa.cargo_features~}}
     {{~#unless @last}}, {{/unless~}}
 {{/each}}]
 
+[dev-dependencies]
+abscissa = { version = "{{abscissa.version}}", features = ["testing"] }
+
 {{#if patch_crates_io~}}
 [patch.crates-io]
 {{patch_crates_io}}

--- a/src/error/framework.rs
+++ b/src/error/framework.rs
@@ -26,6 +26,10 @@ pub enum FrameworkErrorKind {
     #[fail(display = "path error")]
     PathError,
 
+    /// Errors occurring in subprocess
+    #[fail(display = "subprocess error")]
+    ProcessError,
+
     /// Errors involving signals
     #[fail(display = "signal error")]
     SignalError,
@@ -33,6 +37,10 @@ pub enum FrameworkErrorKind {
     /// Errors involving multithreading
     #[fail(display = "thread error")]
     ThreadError,
+
+    /// Timeout performing operation
+    #[fail(display = "operation timed out")]
+    TimeoutError,
 }
 
 impl From<io::Error> for FrameworkError {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -131,6 +131,8 @@ mod runnable;
 mod shutdown;
 #[cfg(all(feature = "signals", unix))]
 pub mod signal;
+#[cfg(feature = "testing")]
+pub mod testing;
 pub mod thread;
 
 // Proc macros

--- a/src/testing.rs
+++ b/src/testing.rs
@@ -1,0 +1,252 @@
+//! Acceptance testing for Abscissa applications.
+
+use crate::error::{
+    FrameworkError,
+    FrameworkErrorKind::{ProcessError, TimeoutError},
+};
+use std::{
+    ffi::OsString,
+    io::{self, Write},
+    process::{Child, Command},
+    time::Duration,
+};
+use termcolor::{BufferWriter, Color, ColorChoice, ColorSpec, WriteColor};
+use wait_timeout::ChildExt;
+
+/// Length of the default timeout in seconds (30 minutes)
+const DEFAULT_TIMEOUT_SECS: u64 = 1800;
+
+/// Run a command via `cargo run`
+#[derive(Clone, Debug)]
+pub struct CargoRunner {
+    /// Command to run (cargo)
+    cmd: OsString,
+
+    /// Arguments to pass to the executable
+    args: Vec<OsString>,
+
+    /// How long to wait until a child exits
+    timeout: Duration,
+}
+
+impl Default for CargoRunner {
+    fn default() -> Self {
+        Self {
+            cmd: "cargo".into(),
+            args: vec![],
+            timeout: Duration::from_secs(DEFAULT_TIMEOUT_SECS),
+        }
+    }
+}
+
+impl CargoRunner {
+    /// Create a new `cargo` runner.
+    pub fn new<I, S>(args: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<OsString>,
+    {
+        let mut runner = Self::default();
+        runner.args(args);
+        runner
+    }
+
+    /// Append an argument to the set of arguments to run
+    pub fn arg<S>(&mut self, arg: S) -> &mut Self
+    where
+        S: Into<OsString>,
+    {
+        self.args.push(arg.into());
+        self
+    }
+
+    /// Append multiple arguments to the set of arguments to run
+    pub fn args<I, S>(&mut self, args: I) -> &mut Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<OsString>,
+    {
+        self.args.extend(args.into_iter().map(|a| a.into()));
+        self
+    }
+
+    /// Set the timeout after which the command should complete
+    pub fn timeout(&mut self, duration: Duration) -> &mut Self {
+        self.timeout = duration;
+        self
+    }
+
+    /// Run the given subcommand
+    pub fn run(&self) -> Result<Process, FrameworkError> {
+        self.print_command().unwrap();
+
+        let child = Command::new(&self.cmd).args(&self.args).spawn()?;
+
+        Ok(Process {
+            child,
+            timeout: self.timeout,
+        })
+    }
+
+    /// Get the exit status for the given subcommand
+    pub fn status(&self) -> Result<ExitStatus, FrameworkError> {
+        self.run()?.wait()
+    }
+
+    /// Print the command we're about to run
+    fn print_command(&self) -> Result<(), io::Error> {
+        let stdout = BufferWriter::stdout(ColorChoice::Auto);
+        let mut buffer = stdout.buffer();
+
+        buffer.set_color(ColorSpec::new().set_fg(Some(Color::Green)))?;
+        write!(&mut buffer, "+ ")?;
+
+        buffer.set_color(ColorSpec::new().set_fg(Some(Color::White)).set_bold(true))?;
+        write!(&mut buffer, "run")?;
+
+        buffer.reset()?;
+
+        let cmd = self.cmd.to_string_lossy();
+        let args: Vec<_> = self.args.iter().map(|arg| arg.to_string_lossy()).collect();
+        writeln!(&mut buffer, ": {} {}", cmd, args.join(" "))?;
+
+        stdout.print(&buffer)
+    }
+}
+
+/// Run a command via `cargo run`
+#[derive(Clone, Debug, Default)]
+pub struct CmdRunner {
+    /// Option to pass as the `--bin` argument to `cargo run`
+    bin: Option<OsString>,
+
+    /// Arguments to pass to the executable
+    args: Vec<OsString>,
+
+    /// Timeout after which command should complete.
+    timeout: Option<Duration>,
+}
+
+impl CmdRunner {
+    /// Provide a `--bin` to `cargo run`. Use `CmdRunner::default()` if you
+    /// only have one binary in your project.
+    pub fn new<S>(bin: S) -> Self
+    where
+        S: Into<OsString>,
+    {
+        Self {
+            bin: Some(bin.into()),
+            args: vec![],
+            timeout: None,
+        }
+    }
+
+    /// Append an argument to the set of arguments to run
+    pub fn arg<S>(&mut self, arg: S) -> &mut Self
+    where
+        S: Into<OsString>,
+    {
+        self.args.push(arg.into());
+        self
+    }
+
+    /// Append multiple arguments to the set of arguments to run
+    pub fn args<I, S>(&mut self, args: I) -> &mut Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<OsString>,
+    {
+        self.args.extend(args.into_iter().map(|a| a.into()));
+        self
+    }
+
+    /// Set the timeout after which the command should complete.
+    ///
+    /// By default `CargoRunner` timeout will be used (30 minutes).
+    pub fn timeout(&mut self, duration: Duration) -> &mut Self {
+        self.timeout = Some(duration);
+        self
+    }
+
+    /// Invoke `cargo run` with the given arguments
+    pub fn run(&self) -> Result<Process, FrameworkError> {
+        let mut runner = CargoRunner::default();
+
+        // Invoke `cargo run`.
+        runner.arg("run");
+
+        // Add optional `--bin` argument.
+        if let Some(ref bin) = self.bin {
+            runner.arg("--bin");
+            runner.arg(bin);
+        }
+
+        if !self.args.is_empty() {
+            runner.arg("--");
+            runner.args(&self.args);
+        }
+
+        runner.run()
+    }
+
+    /// Get the exit status after invoking the given command
+    pub fn status(&self) -> Result<ExitStatus, FrameworkError> {
+        self.run()?.wait()
+    }
+}
+
+/// Subprocess spawned by a `CmdRunner`
+#[derive(Debug)]
+pub struct Process {
+    /// Child process
+    child: Child,
+
+    /// Timeout after which process should complete
+    timeout: Duration,
+}
+
+impl Process {
+    /// Wait for the child to exit
+    pub fn wait(mut self) -> Result<ExitStatus, FrameworkError> {
+        match self.child.wait_timeout(self.timeout)? {
+            Some(status) => {
+                let code = status.code().ok_or_else(|| {
+                    err!(ProcessError, "no exit status returned from subprocess!")
+                })?;
+                Ok(ExitStatus { code })
+            }
+            None => fail!(
+                TimeoutError,
+                "operation timed out after {} seconds",
+                self.timeout.as_secs()
+            ),
+        }
+    }
+}
+
+/// Information about a process's exit status
+#[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
+pub struct ExitStatus {
+    code: i32,
+}
+
+impl ExitStatus {
+    /// Get the exit code
+    pub fn code(&self) -> i32 {
+        self.code
+    }
+
+    /// Did the process exit successfully?
+    pub fn success(&self) -> bool {
+        self.code == 0
+    }
+
+    /// Assert that the process exited successfully
+    pub fn assert_success(&self) {
+        assert_eq!(
+            self.code, 0,
+            "process exited with error status: {}",
+            self.code
+        );
+    }
+}

--- a/tests/generate_app.rs
+++ b/tests/generate_app.rs
@@ -1,9 +1,12 @@
 //! Generate an Abscissa application using the `abscissa` CLI tool and run
 //! tests against it (also `clippy`, `rustfmt`).
 
-use std::{env, ffi::OsStr, fs, path::Path, process::Command};
+#![deny(warnings, missing_docs, unused_import_braces, unused_qualifications)]
+#![forbid(unsafe_code)]
+
+use abscissa::testing::{CargoRunner, CmdRunner};
+use std::{env, fs, path::Path};
 use tempfile::TempDir;
-use walkdir::WalkDir;
 
 /// Name of our test application
 const APP_NAME: &str = "generated_test_app";
@@ -24,49 +27,13 @@ fn test_generated_app() {
 
     generate_app(&app_path);
 
-    let target = env::current_dir()
-        .unwrap()
-        .join("target")
-        .canonicalize()
-        .unwrap();
-    let target_cache_dir = target.join(APP_NAME);
-
-    // TODO(tarcieri): fix caching
-    // restore_target_cache(&target_cache_dir, &app_path.join("target"));
     assert!(env::set_current_dir(&app_path).is_ok());
 
     for test_command in TEST_COMMANDS {
-        run_cargo(test_command.split(" "));
-    }
-
-    if target_cache_dir.exists() {
-        fs::remove_dir_all(&target_cache_dir).unwrap();
-    }
-
-    fs::rename("target", &target_cache_dir).unwrap();
-}
-
-/// Restore the cached `target/` directory (if one exists)
-// TODO(tarcieri): fix caching
-#[allow(dead_code)]
-fn restore_target_cache(src: &Path, dst: &Path) {
-    // No cache available
-    if !src.exists() {
-        return;
-    }
-
-    for entry in WalkDir::new(src) {
-        let src_path = entry.unwrap().path().to_owned();
-        let dst_path = dst.join(src_path.strip_prefix(src).unwrap());
-
-        if src_path.is_file() && !dst_path.exists() {
-            let parent = dst_path.parent().unwrap();
-
-            if !parent.exists() {
-                fs::create_dir_all(parent).unwrap();
-                fs::copy(src_path, dst_path).unwrap();
-            }
-        }
+        CargoRunner::new(test_command.split(" "))
+            .status()
+            .unwrap()
+            .assert_success();
     }
 }
 
@@ -75,15 +42,17 @@ fn generate_app(path: &Path) {
     let cwd = env::current_dir().unwrap();
     let abscissa_crate_patch = format!("abscissa = {{ path = '{}' }}", cwd.display());
 
-    run_cargo(&[
-        "run",
-        "--release",
-        "--",
-        "new",
-        &path.display().to_string(),
-        "--patch-crates-io",
-        &abscissa_crate_patch,
-    ]);
+    // Run `abscissa new` to generate the app
+    CmdRunner::default()
+        .args(&[
+            "new",
+            &path.display().to_string(),
+            "--patch-crates-io",
+            &abscissa_crate_patch,
+        ])
+        .status()
+        .unwrap()
+        .assert_success();
 
     let app_test_dir = path.join("tests");
 
@@ -98,34 +67,4 @@ fn generate_app(path: &Path) {
         )
         .unwrap();
     }
-}
-
-/// Run the `cargo` command with the given arguments
-fn run_cargo<I, S>(args: I)
-where
-    I: IntoIterator<Item = S> + Clone,
-    S: AsRef<OsStr>,
-{
-    let prefix = if atty::is(atty::Stream::Stdout) {
-        "\x1b[1;32m+\x1b[1;37m run\x1b[0m: cargo"
-    } else {
-        "+ run: cargo"
-    };
-
-    // Display the cargo command we're executing before we run it
-    assert!(Command::new("echo")
-        .arg(prefix)
-        .args(args.clone())
-        .status()
-        .unwrap()
-        .success());
-
-    let status = Command::new("cargo").args(args).status().unwrap();
-    let status_code = status.code().unwrap();
-
-    assert_eq!(
-        status_code, 0,
-        "cargo exited with error status: {}",
-        status_code
-    );
 }


### PR DESCRIPTION
Adds an `abscissa::testing` module with `CargoRunner` and `CmdRunner` which is gated under the `testing` feature.

Enables the `testing` feature in the application boilerplate under `dev-dependencies`.

Rewrites the existing app generator tests using this new functionality (which is partially extracted from the original app generator tests), exercising the test subsystem in an act of test inception.