### PR TITLE
Fix usage parsing for entrypoint command

### DIFF
--- a/abscissa_generator/template/src/commands/start.rs.hbs
+++ b/abscissa_generator/template/src/commands/start.rs.hbs
@@ -18,15 +18,16 @@ use abscissa::{Command, Options, Runnable};
 pub struct StartCommand {
     /// To whom are we saying hello?
     #[options(free)]
-    recipient: Option<String>,
+    recipient: Vec<String>,
 }
 
 impl Runnable for StartCommand {
     /// Print "Hello, world!"
     fn run(&self) {
-        match &self.recipient {
-            Some(recipient) => println!("Hello, {}!", recipient),
-            None => println!("Hello, world!"),
+        if self.recipient.is_empty() {
+            println!("Hello, world!");
+        } else {
+            println!("Hello, {}!", self.recipient.join(" "));
         }
     }
 }

--- a/abscissa_generator/template/tests/acceptance.rs.hbs
+++ b/abscissa_generator/template/tests/acceptance.rs.hbs
@@ -7,13 +7,25 @@
 use abscissa::testing::CmdRunner;
 
 #[test]
-fn start_cmd() {
+fn start_no_args() {
     let mut cmd = CmdRunner::default()
-        .args(&["start", "test"])
+        .arg("start")
         .capture_stdout()
         .run()
         .unwrap();
 
-    cmd.stdout().expect_line("Hello, test!");
+    cmd.stdout().expect_line("Hello, world!");
+    cmd.wait().unwrap().expect_success();
+}
+
+#[test]
+fn start_with_args() {
+    let mut cmd = CmdRunner::default()
+        .args(&["start", "acceptance", "test"])
+        .capture_stdout()
+        .run()
+        .unwrap();
+
+    cmd.stdout().expect_line("Hello, acceptance test!");
     cmd.wait().unwrap().expect_success();
 }

--- a/src/bin/abscissa/commands.rs
+++ b/src/bin/abscissa/commands.rs
@@ -5,12 +5,15 @@ mod version;
 
 use self::{new::NewCommand, version::VersionCommand};
 use super::config::CliConfig;
-use abscissa::{Command, Configurable, Options, Runnable};
+use abscissa::{Command, Configurable, Help, Options, Runnable};
 use std::path::PathBuf;
 
 /// Abscissa CLI Subcommands
 #[derive(Runnable, Command, Debug, Options)]
 pub enum CliCommand {
+    #[options(help = "show help for a command")]
+    Help(Help<Self>),
+
     #[options(help = "create a new Abscissa application from a template")]
     New(NewCommand),
 

--- a/src/command/entrypoint.rs
+++ b/src/command/entrypoint.rs
@@ -1,6 +1,6 @@
 //! Toplevel entrypoint command.
 
-use super::Command;
+use super::{Command, Usage};
 use crate::{Config, Configurable, Options, Runnable};
 use std::path::PathBuf;
 
@@ -72,6 +72,11 @@ where
     /// Authors of this program
     fn authors() -> &'static str {
         Cmd::authors()
+    }
+
+    /// Get usage information for a particular subcommand (if available)
+    fn subcommand_usage(command: &str) -> Option<Usage> {
+        Cmd::subcommand_usage(command)
     }
 }
 

--- a/tests/app/exit_status.rs
+++ b/tests/app/exit_status.rs
@@ -18,5 +18,5 @@ fn invalid_args() {
         .capture_stdout()
         .status()
         .unwrap()
-        .expect_code(101);
+        .expect_code(1);
 }


### PR DESCRIPTION
`Entrypoint` was not properly thunking `subcommand_usage` previously.

Also adds some more interesting acceptance tests to the generated template.