### PR TITLE
logging: Fix LevelFilter support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ gumdrop = { version = "0.6", optional = true }
 gumdrop_derive = { version = "0.6", optional = true }
 heck = { version = "0.3", optional = true }
 lazy_static = "1"
-log = { version = "0.4", optional = true }
+log = { version = "0.4", optional = true, features = ["std"] }
 regex = { version = "1", optional = true }
 secrecy = { version = "0.2", optional = true, features = ["serde"] }
 semver = { version = "0.9", optional = true }

--- a/abscissa_generator/template/src/application.rs.hbs
+++ b/abscissa_generator/template/src/application.rs.hbs
@@ -1,8 +1,9 @@
 //! {{title}} Abscissa Application
 
 use crate::{commands::{{~command_type~}}, config::{{~config_type~}}};
-use abscissa::{application, config};
-use abscissa::{Application, EntryPoint, FrameworkError, LoggingConfig, StandardPaths};
+use abscissa::{
+    application, config, logging, Application, EntryPoint, FrameworkError, StandardPaths,
+};
 use lazy_static::lazy_static;
 
 lazy_static! {
@@ -103,11 +104,11 @@ impl Application for {{application_type}} {
     }
 
     /// Get logging configuration from command-line options
-    fn logging_config(&self, command: &EntryPoint<{{~command_type~}}>) -> LoggingConfig {
+    fn logging_config(&self, command: &EntryPoint<{{~command_type~}}>) -> logging::Config {
         if command.verbose {
-            LoggingConfig::verbose()
+            logging::Config::verbose()
         } else {
-            LoggingConfig::default()
+            logging::Config::default()
         }
     }
 }

--- a/src/application.rs
+++ b/src/application.rs
@@ -14,7 +14,7 @@ use crate::{
     component::Component,
     config::{Config, Configurable},
     error::{FrameworkError, FrameworkErrorKind::*},
-    logging::{LoggingComponent, LoggingConfig},
+    logging::{self, LoggingComponent},
     path::{AbsPathBuf, ExePath, RootPath},
     runnable::Runnable,
     shutdown::Shutdown,
@@ -175,8 +175,8 @@ pub trait Application: Default + Sized {
     }
 
     /// Get the logging configuration for this application.
-    fn logging_config(&self, command: &Self::Cmd) -> LoggingConfig {
-        LoggingConfig::default()
+    fn logging_config(&self, command: &Self::Cmd) -> logging::Config {
+        logging::Config::default()
     }
 
     /// Handle a Unix signal received by this application

--- a/src/bin/abscissa/application.rs
+++ b/src/bin/abscissa/application.rs
@@ -2,7 +2,7 @@
 
 use super::{commands::CliCommand, config::CliConfig};
 use abscissa::{
-    self, application, Application, EntryPoint, FrameworkError, LoggingConfig, StandardPaths,
+    self, application, logging, Application, EntryPoint, FrameworkError, StandardPaths,
 };
 use lazy_static::lazy_static;
 
@@ -61,11 +61,11 @@ impl Application for CliApplication {
         Ok(())
     }
 
-    fn logging_config(&self, command: &EntryPoint<CliCommand>) -> LoggingConfig {
+    fn logging_config(&self, command: &EntryPoint<CliCommand>) -> logging::Config {
         if command.verbose {
-            LoggingConfig::verbose()
+            logging::Config::verbose()
         } else {
-            LoggingConfig::default()
+            logging::Config::default()
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -149,8 +149,6 @@ pub use gumdrop_derive::*;
 #[cfg(feature = "config")]
 pub use crate::config::{Config, Configurable};
 pub use crate::error::{Error, Fail, FrameworkError, FrameworkErrorKind};
-#[cfg(feature = "logging")]
-pub use crate::logging::LoggingConfig;
 pub use crate::runnable::Runnable;
 #[cfg(feature = "application")]
 pub use crate::{

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -7,4 +7,4 @@ mod logger;
 
 #[cfg(feature = "application")]
 pub use self::component::LoggingComponent;
-pub use self::config::LoggingConfig;
+pub use self::config::Config;

--- a/src/logging/component.rs
+++ b/src/logging/component.rs
@@ -2,19 +2,19 @@
 
 // TODO(tarcieri): logfile support?
 
-use super::{config::LoggingConfig, logger};
+use super::{config::Config, logger};
 use crate::{component, Application, Component, FrameworkError, Version};
 
 /// Abscissa component for initializing the logging subsystem
 #[derive(Debug, Default)]
 pub struct LoggingComponent {
-    config: LoggingConfig,
+    config: Config,
 }
 
 impl LoggingComponent {
     /// Create a new logging component
-    pub fn new(config: LoggingConfig) -> Result<Self, FrameworkError> {
-        logger::init();
+    pub fn new(config: Config) -> Result<Self, FrameworkError> {
+        logger::init(&config);
         Ok(Self { config })
     }
 }

--- a/src/logging/config.rs
+++ b/src/logging/config.rs
@@ -4,32 +4,32 @@ use log::LevelFilter;
 
 /// Logging configuration
 // TODO: more configurability
-#[derive(Copy, Clone, Debug, Eq, PartialEq)]
-pub struct LoggingConfig {
-    level_filter: LevelFilter,
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct Config {
+    pub(super) level_filter: LevelFilter,
 }
 
-impl LoggingConfig {
+impl Config {
     /// Create a new LoggingConfig object with verbose logging
     pub fn verbose() -> Self {
         LevelFilter::Debug.into()
     }
 }
 
-impl Default for LoggingConfig {
+impl Default for Config {
     fn default() -> Self {
         LevelFilter::Info.into()
     }
 }
 
-impl From<LevelFilter> for LoggingConfig {
-    fn from(level_filter: LevelFilter) -> LoggingConfig {
+impl From<LevelFilter> for Config {
+    fn from(level_filter: LevelFilter) -> Config {
         Self { level_filter }
     }
 }
 
-impl From<LoggingConfig> for LevelFilter {
-    fn from(logging_config: LoggingConfig) -> LevelFilter {
+impl From<Config> for LevelFilter {
+    fn from(logging_config: Config) -> LevelFilter {
         logging_config.level_filter
     }
 }


### PR DESCRIPTION
The new logging subsystem lacked support for configuring the loglevel.

This commit adds it back.