### PR TITLE
generator: Run 'git init' automatically

### DIFF
--- a/abscissa_generator/src/lib.rs
+++ b/abscissa_generator/src/lib.rs
@@ -1,6 +1,6 @@
 //! Templating engine for generating new Abscissa applications
 
-#![deny(warnings, unsafe_code, unused_import_braces, unused_qualifications)]
+#![deny(warnings, unsafe_code, unused_qualifications)]
 #![forbid(unsafe_code)]
 #![doc(
     html_logo_url = "https://www.iqlusion.io/img/github/iqlusioninc/abscissa/abscissa-sq.svg",

--- a/src/bin/abscissa/main.rs
+++ b/src/bin/abscissa/main.rs
@@ -1,5 +1,7 @@
 //! Main entry point for the Abscissa CLI application
 
+#![deny(warnings, unsafe_code, unused_qualifications)]
+
 mod application;
 mod commands;
 mod config;


### PR DESCRIPTION
This is convenient and common in these sorts of generators, e.g. both `cargo new` and `rails new` do it.