### PR TITLE
testing: Simplify error handling

### DIFF
--- a/abscissa_generator/template/tests/acceptance.rs.hbs
+++ b/abscissa_generator/template/tests/acceptance.rs.hbs
@@ -8,12 +8,7 @@ use abscissa::testing::CmdRunner;
 
 #[test]
 fn start_no_args() {
-    let mut cmd = CmdRunner::default()
-        .arg("start")
-        .capture_stdout()
-        .run()
-        .unwrap();
-
+    let mut cmd = CmdRunner::default().arg("start").capture_stdout().run();
     cmd.stdout().expect_line("Hello, world!");
     cmd.wait().unwrap().expect_success();
 }
@@ -23,8 +18,7 @@ fn start_with_args() {
     let mut cmd = CmdRunner::default()
         .args(&["start", "acceptance", "test"])
         .capture_stdout()
-        .run()
-        .unwrap();
+        .run();
 
     cmd.stdout().expect_line("Hello, acceptance test!");
     cmd.wait().unwrap().expect_success();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-//! Abscissa: an application microframework
+//! ![Abscissa](https://www.iqlusion.io/img/github/iqlusioninc/abscissa/abscissa.svg)
 //!
 //! Abscissa is a microframework for building Rust applications (either CLI tools
 //! or network services), aiming to provide a large number of features with a
@@ -23,8 +23,7 @@
 //!
 //! # Creating a new Abscissa application
 //!
-//! If you already have Rust installed, the following commands will generate an
-//! Abscissa application skeleton:
+//! The following commands will generate an Abscissa application skeleton:
 //!
 //! ```text
 //! $ cargo install abscissa

--- a/tests/app/exit_status.rs
+++ b/tests/app/exit_status.rs
@@ -7,7 +7,6 @@ fn no_args() {
     CmdRunner::default()
         .capture_stdout()
         .status()
-        .unwrap()
         .expect_success();
 }
 
@@ -17,6 +16,5 @@ fn invalid_args() {
         .arg("foobar") // invalid arg
         .capture_stdout()
         .status()
-        .unwrap()
         .expect_code(1);
 }

--- a/tests/generate_app.rs
+++ b/tests/generate_app.rs
@@ -28,7 +28,6 @@ fn test_generated_app() {
     for test_command in TEST_COMMANDS {
         CargoRunner::new(test_command.split(" "))
             .status()
-            .unwrap()
             .expect_success();
     }
 }
@@ -48,7 +47,6 @@ fn generate_app(path: &Path) {
             &abscissa_crate_patch,
         ])
         .status()
-        .unwrap()
         .expect_success();
 
     let app_test_dir = path.join("tests");


### PR DESCRIPTION
Changes the `::run` and `::status` methods to panic, removing the need for users writing tests to call `unwrap()` on them.

It doesn't make sense for end-users to handle these errors, so this improves the ergonomics by making the API simpler.