### PR TITLE
v0.1.0

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,32 @@
+## [0.1.0] (2019-07-02)
+
+- components: Add basic downcasting support ([#72])
+- components: impl `PartialOrd` for `Box<dyn Component>` ([#71])
+- generator: Run `git init` automatically ([#69])
+- abscissa new: add `--force` option ([#68])
+- testing: Support for capturing/asserting on streams ([#65])
+- testing: Add initial testing subsystem ([#64])
+- Upgrade to `gumdrop` v0.6 ([#63])
+- command: Show full usage on error with no args ([#61])
+- Command usage improvements ([#59])
+- entrypoint: Use config arg ([#58])
+- terminal: Persistent stdout/stderr streams ([#57])
+- Integrated logging support ([#56])
+- abscissa_generator: Use `Error`/`ErrorKind` names ([#55])
+- Add `app_config()`/`app_reader()`/`app_writer()` and `prelude` to template ([#52])
+- abscissa_derive: Test all proc macros ([#51])
+- Signal handling using the signal-hook crate ([#50])
+- thread: Wrappers for spawning threads ([#49])
+- Impl `Runnable`/`RunnableMut` for `Box<dyn Fn/FnMut>` ([#48])
+- Switch from `term` crate to `termcolor` crate ([#47])
+- Rename `Callable` to `Runnable` ([#45])
+- Bump minimum Rust version to 1.35.0 ([#44])
+- Use `secrecy` crate for secret-keeping ([#43], [#53])
+- Refactor `Application` and `Config` ([#42])
+- abscissa_generator: Generate new apps with `abscissa new` ([#38], [#39], [#40], [#41])
+- config: Refactor to eliminate `macro_rules!` ([#34])
+- Update to Rust 2018 edition ([#30], [#36])
+
 ## [0.0.6] (2018-10-12)
 
 - Upgrade to zeroize v0.4 ([#24])
@@ -28,6 +57,38 @@
 
 - Initial release
 
+[0.1.0]: https://github.com/iqlusioninc/abscissa/pull/77
+[#72]: https://github.com/iqlusioninc/abscissa/pull/72
+[#71]: https://github.com/iqlusioninc/abscissa/pull/71
+[#69]: https://github.com/iqlusioninc/abscissa/pull/69
+[#68]: https://github.com/iqlusioninc/abscissa/pull/68
+[#65]: https://github.com/iqlusioninc/abscissa/pull/65
+[#64]: https://github.com/iqlusioninc/abscissa/pull/64
+[#63]: https://github.com/iqlusioninc/abscissa/pull/63
+[#61]: https://github.com/iqlusioninc/abscissa/pull/61
+[#59]: https://github.com/iqlusioninc/abscissa/pull/59
+[#58]: https://github.com/iqlusioninc/abscissa/pull/58
+[#57]: https://github.com/iqlusioninc/abscissa/pull/57
+[#56]: https://github.com/iqlusioninc/abscissa/pull/56
+[#55]: https://github.com/iqlusioninc/abscissa/pull/55
+[#53]: https://github.com/iqlusioninc/abscissa/pull/53
+[#52]: https://github.com/iqlusioninc/abscissa/pull/52
+[#51]: https://github.com/iqlusioninc/abscissa/pull/51
+[#50]: https://github.com/iqlusioninc/abscissa/pull/50
+[#49]: https://github.com/iqlusioninc/abscissa/pull/49
+[#48]: https://github.com/iqlusioninc/abscissa/pull/48
+[#47]: https://github.com/iqlusioninc/abscissa/pull/47
+[#45]: https://github.com/iqlusioninc/abscissa/pull/45
+[#44]: https://github.com/iqlusioninc/abscissa/pull/44
+[#43]: https://github.com/iqlusioninc/abscissa/pull/43
+[#42]: https://github.com/iqlusioninc/abscissa/pull/42
+[#41]: https://github.com/iqlusioninc/abscissa/pull/41
+[#40]: https://github.com/iqlusioninc/abscissa/pull/40
+[#39]: https://github.com/iqlusioninc/abscissa/pull/39
+[#38]: https://github.com/iqlusioninc/abscissa/pull/38
+[#36]: https://github.com/iqlusioninc/abscissa/pull/36
+[#34]: https://github.com/iqlusioninc/abscissa/pull/34
+[#30]: https://github.com/iqlusioninc/abscissa/pull/30
 [0.0.6]: https://github.com/iqlusioninc/abscissa/pull/25
 [#24]: https://github.com/iqlusioninc/abscissa/pull/24
 [0.0.5]: https://github.com/iqlusioninc/abscissa/pull/23

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2,10 +2,10 @@
 # It is not intended for manual editing.
 [[package]]
 name = "abscissa"
-version = "0.1.0-rc.0"
+version = "0.1.0"
 dependencies = [
- "abscissa_derive 0.1.0-rc.0",
- "abscissa_generator 0.1.0-rc.0",
+ "abscissa_derive 0.1.0",
+ "abscissa_generator 0.1.0",
  "canonical-path 2.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -27,7 +27,7 @@ dependencies = [
 
 [[package]]
 name = "abscissa_derive"
-version = "0.1.0-rc.0"
+version = "0.1.0"
 dependencies = [
  "heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -38,7 +38,7 @@ dependencies = [
 
 [[package]]
 name = "abscissa_generator"
-version = "0.1.0-rc.0"
+version = "0.1.0"
 dependencies = [
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "handlebars 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ description = """
               Application microframework with support for command-line option parsing,
               configuration, error handling, logging, and terminal interactions
               """
-version     = "0.1.0-rc.0" # Also update html_root_url in lib.rs when bumping this
+version     = "0.1.0" # Also update html_root_url in lib.rs when bumping this
 license     = "Apache-2.0"
 authors     = ["Tony Arcieri <tony@iqlusion.io>"]
 edition     = "2018"
@@ -15,8 +15,8 @@ categories  = ["command-line-interface", "rust-patterns"]
 keywords    = ["abscissa", "cli", "application", "framework", "service"]
 
 [dependencies]
-abscissa_derive = { version = "0.1.0-rc.0", path = "abscissa_derive" }
-abscissa_generator = { version = "0.1.0-rc.0", optional = true, path = "abscissa_generator" }
+abscissa_derive = { version = "0.1.0", path = "abscissa_derive" }
+abscissa_generator = { version = "0.1.0", optional = true, path = "abscissa_generator" }
 canonical-path = "2"
 chrono = { version = "0.4", optional = true, features = ["serde"] }
 failure = "0.1"

--- a/README.md
+++ b/README.md
@@ -303,7 +303,7 @@ without any additional terms or conditions.
 
 [abscissa]: https://crates.io/crates/abscissa
 [abscissa_derive]: https://crates.io/crates/abscissa_derive
-[aho-corasick]: https://crates.io/crates/arc-swap
+[aho-corasick]: https://crates.io/crates/aho-corasick
 [arc-swap]: https://crates.io/crates/arc-swap
 [autocfg]: https://crates.io/crates/autocfg
 [backtrace]: https://crates.io/crates/backtrace
@@ -312,7 +312,7 @@ without any additional terms or conditions.
 [canonical-path]: https://crates.io/crates/canonical-path
 [cc]: https://crates.io/crates/cc
 [cfg-if]: https://crates.io/crates/cfg-if
-[chrono]: https://crates.io/crates/chrono/
+[chrono]: https://crates.io/crates/chrono
 [failure]: https://crates.io/crates/failure
 [failure_derive]: https://crates.io/crates/failure_derive
 [gumdrop]: https://crates.io/crates/gumdrop

--- a/abscissa_derive/Cargo.toml
+++ b/abscissa_derive/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name        = "abscissa_derive"
 description = "Custom derive support for the abscissa application microframework"
-version     = "0.1.0-rc.0" # Also update html_root_url in lib.rs when bumping this
+version     = "0.1.0" # Also update html_root_url in lib.rs when bumping this
 license     = "Apache-2.0"
 authors     = ["Tony Arcieri <tony@iqlusion.io>"]
 edition     = "2018"

--- a/abscissa_derive/src/lib.rs
+++ b/abscissa_derive/src/lib.rs
@@ -5,7 +5,7 @@
 #![forbid(unsafe_code)]
 #![doc(
     html_logo_url = "https://www.iqlusion.io/img/github/iqlusioninc/abscissa/abscissa-sq.svg",
-    html_root_url = "https://docs.rs/abscissa_derive/0.1.0-rc.0"
+    html_root_url = "https://docs.rs/abscissa_derive/0.1.0"
 )]
 
 extern crate proc_macro;

--- a/abscissa_generator/Cargo.toml
+++ b/abscissa_generator/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name        = "abscissa_generator"
 description = "Template-based generator for creating new Abscissa applications"
-version     = "0.1.0-rc.0" # Also update html_root_url in lib.rs when bumping this
+version     = "0.1.0" # Also update html_root_url in lib.rs when bumping this
 license     = "Apache-2.0"
 authors     = ["Tony Arcieri <tony@iqlusion.io>"]
 edition     = "2018"

--- a/abscissa_generator/src/lib.rs
+++ b/abscissa_generator/src/lib.rs
@@ -4,7 +4,7 @@
 #![forbid(unsafe_code)]
 #![doc(
     html_logo_url = "https://www.iqlusion.io/img/github/iqlusioninc/abscissa/abscissa-sq.svg",
-    html_root_url = "https://docs.rs/abscissa_generator/0.1.0-rc.0"
+    html_root_url = "https://docs.rs/abscissa_generator/0.1.0"
 )]
 
 pub mod properties;

--- a/abscissa_generator/template/src/bin/app/main.rs.hbs
+++ b/abscissa_generator/template/src/bin/app/main.rs.hbs
@@ -1,5 +1,8 @@
 //! Main entry point for {{title}}
 
+#![deny(warnings, missing_docs, trivial_casts, unused_qualifications)]
+#![forbid(unsafe_code)]
+
 use {{name}}::application::APPLICATION;
 
 /// Boot {{title}}

--- a/abscissa_generator/template/src/lib.rs.hbs
+++ b/abscissa_generator/template/src/lib.rs.hbs
@@ -2,14 +2,7 @@
 //!
 //! {{description}}
 
-#![deny(
-    warnings,
-    missing_docs,
-    trivial_casts,
-    trivial_numeric_casts,
-    unused_import_braces,
-    unused_qualifications
-)]
+#![deny(warnings, missing_docs, trivial_casts, unused_qualifications)]
 #![forbid(unsafe_code)]
 
 pub mod application;

--- a/src/bin/abscissa/main.rs
+++ b/src/bin/abscissa/main.rs
@@ -1,6 +1,7 @@
 //! Main entry point for the Abscissa CLI application
 
-#![deny(warnings, unsafe_code, unused_qualifications)]
+#![deny(warnings, missing_docs, trivial_casts, unused_qualifications)]
+#![forbid(unsafe_code)]
 
 mod application;
 mod commands;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -93,7 +93,7 @@
 #![forbid(unsafe_code)]
 #![doc(
     html_logo_url = "https://www.iqlusion.io/img/github/iqlusioninc/abscissa/abscissa-sq.svg",
-    html_root_url = "https://docs.rs/abscissa/0.1.0-rc.0"
+    html_root_url = "https://docs.rs/abscissa/0.1.0"
 )]
 
 /// Abscissa version


### PR DESCRIPTION
- components: Add basic downcasting support (#72)
- components: impl `PartialOrd` for `Box<dyn Component>` (#71)
- generator: Run `git init` automatically (#69)
- abscissa new: add `--force` option (#68)
- testing: Support for capturing/asserting on streams (#65)
- testing: Add initial testing subsystem (#64)
- Upgrade to `gumdrop` v0.6 (#63)
- command: Show full usage on error with no args (#61)
- Command usage improvements (#59)
- entrypoint: Use config arg (#58)
- terminal: Persistent stdout/stderr streams (#57)
- Integrated logging support (#56)
- abscissa_generator: Use `Error`/`ErrorKind` names (#55)
- Add `app_config()`/`app_reader()`/`app_writer()` and `prelude` to template (#52)
- abscissa_derive: Test all proc macros (#51)
- Signal handling using the signal-hook crate (#50)
- thread: Wrappers for spawning threads (#49)
- Impl `Runnable`/`RunnableMut` for `Box<dyn Fn/FnMut>` (#48)
- Switch from `term` crate to `termcolor` crate (#47)
- Rename `Callable` to `Runnable` (#45)
- Bump minimum Rust version to 1.35.0 (#44)
- Use `secrecy` crate for secret-keeping (#43, #53)
- Refactor `Application` and `Config` (#42)
- abscissa_generator: Generate new apps with `abscissa new` (#38, #39, #40, #41)
- config: Refactor to eliminate `macro_rules!` (#34)
- Update to Rust 2018 edition (#30, #36)