### PR TITLE
Configuration loading improvements (fixes #79)

### DIFF
--- a/abscissa_generator/template/src/commands.rs.hbs
+++ b/abscissa_generator/template/src/commands.rs.hbs
@@ -15,7 +15,7 @@ mod version;
 
 use self::{start::StartCommand, version::VersionCommand};
 use crate::config::{{~config_type~}};
-use abscissa::{Command, Configurable, Help, Options, Runnable};
+use abscissa::{config::Override, Command, Configurable, FrameworkError, Help, Options, Runnable};
 use std::path::PathBuf;
 
 /// {{title}} Subcommands
@@ -36,9 +36,23 @@ pub enum {{command_type}} {
 
 /// This trait allows you to define how application configuration is loaded.
 impl Configurable<{{~config_type~}}> for {{command_type}} {
+    // Have `config_path` return `Some(path)` in order to trigger the
+    // application configuration being loaded.
     fn config_path(&self) -> Option<PathBuf> {
-        // Have `config_path` return `Some(path)` in order to trigger the
-        // application configuration being loaded.
         None
+    }
+
+    // Apply changes to the config after it's been loaded, e.g. overriding
+    // values in a config file using command-line options.
+    //
+    // This can be safely deleted if you don't intend to use it.
+    fn process_config(
+        &self,
+        config: {{config_type}},
+    ) -> Result<{{~config_type~}}, FrameworkError> {
+        match self {
+            {{command_type}}::Start(cmd) => cmd.override_config(config),
+            _ => Ok(config),
+        }
     }
 }

--- a/abscissa_generator/template/src/commands/start.rs.hbs
+++ b/abscissa_generator/template/src/commands/start.rs.hbs
@@ -5,7 +5,8 @@
 #[allow(unused_imports)]
 use crate::prelude::*;
 
-use abscissa::{Command, Options, Runnable};
+use crate::config::{{~config_type~}};
+use abscissa::{config, Command, FrameworkError, Options, Runnable};
 
 /// `start` subcommand
 ///
@@ -29,5 +30,21 @@ impl Runnable for StartCommand {
         } else {
             println!("Hello, {}!", self.recipient.join(" "));
         }
+    }
+}
+
+impl config::Override<{{~config_type~}}> for StartCommand {
+    // Process the given command line options, overriding settings from
+    // a configuration file using explicit flags taken from command-line
+    // arguments.
+    fn override_config(
+        &self,
+        mut config: {{config_type}},
+    ) -> Result<{{config_type}}, FrameworkError> {
+        if !self.recipient.is_empty() {
+            config.example_section.example_value = self.recipient.join(" ");
+        }
+
+        Ok(config)
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,10 +1,10 @@
 //! Support for managing global configuration, as well as loading it from TOML
 
 mod configurable;
-mod merge;
+mod overrides;
 mod reader;
 
-pub use self::{configurable::Configurable, merge::MergeOptions, reader::Reader};
+pub use self::{configurable::Configurable, overrides::Override, reader::Reader};
 use crate::{
     error::{FrameworkError, FrameworkErrorKind::ConfigError},
     path::AbsPath,

--- a/src/config/configurable.rs
+++ b/src/config/configurable.rs
@@ -1,25 +1,19 @@
 //! Configuration loader
 
 use super::Config;
-use crate::{error::FrameworkError, path::AbsPath};
+use crate::error::FrameworkError;
 use std::path::PathBuf;
 
 /// Command type with which a configuration file is associated
-pub trait Configurable<C: Config> {
+pub trait Configurable<Cfg: Config> {
     /// Path to the command's configuration file. Returns an error by default.
     fn config_path(&self) -> Option<PathBuf> {
         None
     }
 
-    /// Load the configuration for this command
-    fn load_config_file<P: AsRef<AbsPath>>(&self, path: &P) -> Result<C, FrameworkError> {
-        self.preprocess_config(C::load_toml_file(path)?)
-    }
-
     /// Process the configuration after it has been loaded, potentially
     /// modifying it or returning an error if options are incompatible
-    #[allow(unused_mut)]
-    fn preprocess_config(&self, mut config: C) -> Result<C, FrameworkError> {
+    fn process_config(&self, config: Cfg) -> Result<Cfg, FrameworkError> {
         Ok(config)
     }
 }

--- a/src/config/overrides.rs
+++ b/src/config/overrides.rs
@@ -1,13 +1,9 @@
-//! Support for sourcing/overriding configuration values from arguments
-//! given on the command-line.
+//! Override values in the configuration file with command-line options
 
-use crate::Options;
+use crate::{Command, Config, FrameworkError};
 
-/// Merge the given options into this configuration. This allows setting of
-/// global configuration values using command-line options, and also unifies
-/// the global config as the one way to get application settings.
-#[allow(unused_variables)]
-pub trait MergeOptions<O: Options>: Sized {
+/// Use options from the given `Command` to override settings in the config.
+pub trait Override<Cfg: Config>: Command {
     /// Process the given command line options, overriding settings from
     /// a configuration file using explicit flags taken from command-line
     /// arguments.
@@ -16,7 +12,7 @@ pub trait MergeOptions<O: Options>: Sized {
     /// settings when dealing with both a config file and options passed
     /// on the command line, and a unified way of accessing this information
     /// from components or in the application: from the global config.
-    fn merge(self, options: &O) -> Self {
-        self
+    fn override_config(&self, config: Cfg) -> Result<Cfg, FrameworkError> {
+        Ok(config)
     }
 }


### PR DESCRIPTION
- Have `command::EntryPoint` delegate its `Configurable` impl to the command it wraps.
- Simplify configuration loading logic in `Application`.
- Rename `config::MergeOptions` to `config::Override` and provide an example of how to use it in the boilerplate.