### PR TITLE
generator: Add config filename boilerplate to template (closes #80)

### DIFF
--- a/abscissa_generator/template/src/commands.rs.hbs
+++ b/abscissa_generator/template/src/commands.rs.hbs
@@ -18,6 +18,9 @@ use crate::config::{{~config_type~}};
 use abscissa::{config::Override, Command, Configurable, FrameworkError, Help, Options, Runnable};
 use std::path::PathBuf;
 
+/// {{title}} Configuration Filename
+pub const CONFIG_FILE: &str = "{{name}}.toml";
+
 /// {{title}} Subcommands
 #[derive(Command, Debug, Options, Runnable)]
 pub enum {{command_type}} {
@@ -36,16 +39,25 @@ pub enum {{command_type}} {
 
 /// This trait allows you to define how application configuration is loaded.
 impl Configurable<{{~config_type~}}> for {{command_type}} {
-    // Have `config_path` return `Some(path)` in order to trigger the
-    // application configuration being loaded.
+    /// Location of the configuration file
     fn config_path(&self) -> Option<PathBuf> {
-        None
+        // Check if the config file exists, and if it does not, ignore it.
+        // If you'd like for a missing configuration file to be a hard error
+        // instead, always return `Some(CONFIG_FILE)` here.
+        let filename = PathBuf::from(CONFIG_FILE);
+
+        if filename.exists() {
+            Some(filename)
+        } else {
+            None
+        }
     }
 
-    // Apply changes to the config after it's been loaded, e.g. overriding
-    // values in a config file using command-line options.
-    //
-    // This can be safely deleted if you don't intend to use it.
+    /// Apply changes to the config after it's been loaded, e.g. overriding
+    /// values in a config file using command-line options.
+    ///
+    /// This can be safely deleted if you don't want to override config
+    /// settings from command-line options.
     fn process_config(
         &self,
         config: {{config_type}},


### PR DESCRIPTION
This adds boilerplate which includes the config filename, checks if it exists, and if not, ignores it.

Including this check in the boilerplate, and the explanatory comments around it, should hopefully be sufficient to address questions in #80.