### PR TITLE
generator: Add Default impl to generated config

### DIFF
--- a/abscissa_generator/template/src/commands/start.rs.hbs
+++ b/abscissa_generator/template/src/commands/start.rs.hbs
@@ -42,7 +42,7 @@ impl config::Override<{{~config_type~}}> for StartCommand {
         mut config: {{config_type}},
     ) -> Result<{{config_type}}, FrameworkError> {
         if !self.recipient.is_empty() {
-            config.example_section.example_value = self.recipient.join(" ");
+            config.hello.recipient = self.recipient.join(" ");
         }
 
         Ok(config)

--- a/abscissa_generator/template/src/config.rs.hbs
+++ b/abscissa_generator/template/src/config.rs.hbs
@@ -12,12 +12,38 @@ use serde::{Deserialize, Serialize};
 #[serde(deny_unknown_fields)]
 pub struct {{config_type}} {
     /// An example configuration section
-    pub example_section: ExampleSection,
+    pub hello: ExampleSection,
 }
 
-/// Example configuration section
+/// Default configuration settings.
+///
+/// Customize this to meet your needs, or delete it if you don't intend to
+/// use it. However, keep in mind it may be useful for testing (see acceptance
+/// tests for ways to use it).
+///
+/// Also note: if your needs are as simple as below, you can
+/// use `#[derive(Default)]` instead.
+impl Default for {{config_type}} {
+    fn default() -> Self {
+        {{config_type}} {
+            hello: ExampleSection::default(),
+        }
+    }
+}
+
+/// Example configuration section.
+///
+/// Delete this and replace it with your actual configuration structs.
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct ExampleSection {
     /// Example configuration value
-    pub example_value: String,
+    pub recipient: String,
+}
+
+impl Default for ExampleSection {
+    fn default() -> Self {
+        Self {
+            recipient: "world".to_owned(),
+        }
+    }
 }


### PR DESCRIPTION
This might be something the framework should require and leverage, so apps always have a default configuration to start with which is replaced with values from the config file once loaded.

For now though, the framework does not require the config types impl `Default`, and it's merely a recommended best practice (it is potentially very helpful for testing).