### PR TITLE
config: Mandate Default bound + testing support

### DIFF
--- a/abscissa_generator/template/src/application.rs.hbs
+++ b/abscissa_generator/template/src/application.rs.hbs
@@ -64,8 +64,8 @@ impl Application for {{application_type}} {
     type Paths = StandardPaths;
 
     /// Accessor for application configuration.
-    fn config(&self) -> Option<&{{~config_type}}> {
-        self.config.as_ref()
+    fn config(&self) -> &{{~config_type}} {
+        self.config.as_ref().expect("config not loaded")
     }
 
     /// Borrow the application state immutably.
@@ -93,13 +93,10 @@ impl Application for {{application_type}} {
     /// Called regardless of whether config is loaded to indicate this is the
     /// time in app lifecycle when configuration would be loaded if
     /// possible.
-    fn after_config(&mut self, config: Option<Self::Cfg>) -> Result<(), FrameworkError> {
-        // Provide configuration to all component `after_config()` handlers
-        for component in self.state.components.iter_mut() {
-            component.after_config(config.as_ref())?;
-        }
-
-        self.config = config;
+    fn after_config(&mut self, config: Self::Cfg) -> Result<(), FrameworkError> {
+        // Configure components
+        self.state.components.after_config(&config)?;
+        self.config = Some(config);
         Ok(())
     }
 

--- a/abscissa_generator/template/src/commands/start.rs.hbs
+++ b/abscissa_generator/template/src/commands/start.rs.hbs
@@ -2,7 +2,6 @@
 
 /// App-local prelude includes `app_reader()`/`app_writer()`/`app_config()`
 /// accessors along with logging macros. Customize as you see fit.
-#[allow(unused_imports)]
 use crate::prelude::*;
 
 use crate::config::{{~config_type~}};
@@ -23,13 +22,10 @@ pub struct StartCommand {
 }
 
 impl Runnable for StartCommand {
-    /// Print "Hello, world!"
+    /// Start the application.
     fn run(&self) {
-        if self.recipient.is_empty() {
-            println!("Hello, world!");
-        } else {
-            println!("Hello, {}!", self.recipient.join(" "));
-        }
+        let config = app_config();
+        println!("Hello, {}!", &config.hello.recipient);
     }
 }
 

--- a/abscissa_generator/template/src/config.rs.hbs
+++ b/abscissa_generator/template/src/config.rs.hbs
@@ -17,12 +17,8 @@ pub struct {{config_type}} {
 
 /// Default configuration settings.
 ///
-/// Customize this to meet your needs, or delete it if you don't intend to
-/// use it. However, keep in mind it may be useful for testing (see acceptance
-/// tests for ways to use it).
-///
-/// Also note: if your needs are as simple as below, you can
-/// use `#[derive(Default)]` instead.
+/// Note: if your needs are as simple as below, you can
+/// use `#[derive(Default)]` on {{config_type}} instead.
 impl Default for {{config_type}} {
     fn default() -> Self {
         Self {

--- a/abscissa_generator/template/tests/acceptance.rs.hbs
+++ b/abscissa_generator/template/tests/acceptance.rs.hbs
@@ -1,10 +1,17 @@
 //! Acceptance test: runs the application as a subprocess and asserts its
 //! output for given argument combinations matches what is expected.
 //!
+//! Modify and/or delete these as you see fit to test the specific needs of
+//! your application.
+//!
 //! For more information, see:
 //! <https://docs.rs/abscissa/latest/abscissa/testing/index.html>
 
+#![deny(warnings, missing_docs, trivial_casts, unused_qualifications)]
+#![forbid(unsafe_code)]
+
 use abscissa::testing::prelude::*;
+use {{name}}::config::{{config_type}};
 use lazy_static::lazy_static;
 
 lazy_static! {
@@ -17,6 +24,7 @@ lazy_static! {
     pub static ref RUNNER: CmdRunner = CmdRunner::default();
 }
 
+/// Use `{{config_type}}::default()` value if no config or args
 #[test]
 fn start_no_args() {
     let mut runner = RUNNER.clone();
@@ -25,10 +33,41 @@ fn start_no_args() {
     cmd.wait().unwrap().expect_success();
 }
 
+/// Use command-line argument value
 #[test]
 fn start_with_args() {
     let mut runner = RUNNER.clone();
     let mut cmd = runner
+        .args(&["start", "acceptance", "test"])
+        .capture_stdout()
+        .run();
+
+    cmd.stdout().expect_line("Hello, acceptance test!");
+    cmd.wait().unwrap().expect_success();
+}
+
+/// Use configured value
+#[test]
+fn start_with_config_no_args() {
+    let mut config = {{config_type}}::default();
+    config.hello.recipient = "configured recipient".to_owned();
+    let expected_line = format!("Hello, {}!", &config.hello.recipient);
+
+    let mut runner = RUNNER.clone();
+    let mut cmd = runner.config(&config).arg("start").capture_stdout().run();
+    cmd.stdout().expect_line(&expected_line);
+    cmd.wait().unwrap().expect_success();
+}
+
+/// Override configured value with command-line argument
+#[test]
+fn start_with_config_and_args() {
+    let mut config = {{config_type}}::default();
+    config.hello.recipient = "configured recipient".to_owned();
+
+    let mut runner = RUNNER.clone();
+    let mut cmd = runner
+        .config(&config)
         .args(&["start", "acceptance", "test"])
         .capture_stdout()
         .run();

--- a/src/bin/abscissa/application.rs
+++ b/src/bin/abscissa/application.rs
@@ -35,8 +35,8 @@ impl Application for CliApplication {
     type Cfg = CliConfig;
     type Paths = StandardPaths;
 
-    fn config(&self) -> Option<&CliConfig> {
-        self.config.as_ref()
+    fn config(&self) -> &CliConfig {
+        self.config.as_ref().expect("config not loaded")
     }
 
     fn state(&self) -> &application::State<Self> {
@@ -52,12 +52,12 @@ impl Application for CliApplication {
         self.state.components.register(components)
     }
 
-    fn after_config(&mut self, config: Option<Self::Cfg>) -> Result<(), FrameworkError> {
+    fn after_config(&mut self, config: Self::Cfg) -> Result<(), FrameworkError> {
         for component in self.state.components.iter_mut() {
-            component.after_config(config.as_ref())?;
+            component.after_config(&config)?;
         }
 
-        self.config = config;
+        self.config = Some(config);
         Ok(())
     }
 

--- a/src/bin/abscissa/config.rs
+++ b/src/bin/abscissa/config.rs
@@ -4,7 +4,7 @@ use abscissa::config::Config;
 use serde::{Deserialize, Serialize};
 
 /// Abscissa CLI Config
-#[derive(Config, Clone, Debug, Deserialize, Serialize)]
+#[derive(Config, Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct CliConfig {
     // TODO(tarcieri): configuration file?

--- a/src/command/entrypoint.rs
+++ b/src/command/entrypoint.rs
@@ -13,11 +13,11 @@ where
     Cmd: Command + Runnable,
 {
     /// Path to the configuration file
-    #[options(help = "path to configuration file")]
+    #[options(short = "c", help = "path to configuration file")]
     pub config: Option<PathBuf>,
 
     /// Obtain help about the current command
-    #[options(help = "print help message")]
+    #[options(short = "h", help = "print help message")]
     pub help: bool,
 
     /// Increase verbosity setting

--- a/src/component.rs
+++ b/src/component.rs
@@ -38,7 +38,7 @@ where
 
     /// Lifecycle event called when application configuration should be loaded
     /// if it were possible.
-    fn after_config(&mut self, app: Option<&A::Cfg>) -> Result<(), FrameworkError> {
+    fn after_config(&mut self, config: &A::Cfg) -> Result<(), FrameworkError> {
         Ok(())
     }
 

--- a/src/component/registry.rs
+++ b/src/component/registry.rs
@@ -63,6 +63,15 @@ where
         Ok(())
     }
 
+    /// Callback fired by application when configuration has been loaded
+    pub fn after_config(&mut self, config: &A::Cfg) -> Result<(), FrameworkError> {
+        for component in self.iter_mut() {
+            component.after_config(config)?;
+        }
+
+        Ok(())
+    }
+
     /// Iterate over the components mutably.
     pub fn iter(&mut self) -> slice::Iter<Box<dyn Component<A>>> {
         self.components.iter()

--- a/src/config.rs
+++ b/src/config.rs
@@ -15,7 +15,7 @@ use serde::de::DeserializeOwned;
 use std::{fmt::Debug, fs::File, io::Read};
 
 /// Trait for Abscissa configuration data structures
-pub trait Config: Debug + DeserializeOwned {
+pub trait Config: Debug + Default + DeserializeOwned {
     /// Load the configuration from the given TOML string
     fn load_toml<T: AsRef<str>>(toml_string: T) -> Result<Self, FrameworkError> {
         Ok(toml::from_str(toml_string.as_ref())?)

--- a/src/config/reader.rs
+++ b/src/config/reader.rs
@@ -26,14 +26,6 @@ where
     type Target = A::Cfg;
 
     fn deref(&self) -> &A::Cfg {
-        self.0.config().unwrap_or_else(|| not_loaded())
+        self.0.config()
     }
-}
-
-/// Error handler called if `get()` is invoked before the global
-/// application config has been loaded.
-///
-/// This indicates a bug in the program accessing this type.
-fn not_loaded() -> ! {
-    panic!("Abscissa application config accessed before it has been initialized!")
 }

--- a/src/logging/component.rs
+++ b/src/logging/component.rs
@@ -35,8 +35,8 @@ where
     }
 
     /// Initialize this component at the time the framework boots
-    fn after_config(&mut self, _config: Option<&A::Cfg>) -> Result<(), FrameworkError> {
-        // TODO(tarcieri): set logging configuration
+    fn after_config(&mut self, _config: &A::Cfg) -> Result<(), FrameworkError> {
+        // TODO(tarcieri): set logging configuration here instead of earlier?
         Ok(())
     }
 }

--- a/src/terminal/component.rs
+++ b/src/terminal/component.rs
@@ -32,7 +32,7 @@ where
     }
 
     /// Initialize this component at the time the framework boots
-    fn after_config(&mut self, _app: Option<&A::Cfg>) -> Result<(), FrameworkError> {
+    fn after_config(&mut self, _config: &A::Cfg) -> Result<(), FrameworkError> {
         Ok(())
     }
 }

--- a/src/testing.rs
+++ b/src/testing.rs
@@ -8,6 +8,7 @@
 //!
 //! The main entrypoint for running tests is [abscissa::testing::CmdRunner].
 
+mod config;
 pub mod prelude;
 pub mod process;
 mod runner;

--- a/src/testing/config.rs
+++ b/src/testing/config.rs
@@ -1,0 +1,86 @@
+//! Support for writing config files and using them in tests
+
+use crate::time::Utc;
+use serde::Serialize;
+use std::{
+    env,
+    ffi::OsStr,
+    fs::{self, File, OpenOptions},
+    io::{self, Write},
+    path::{Path, PathBuf},
+};
+
+/// Number of times to attempt to create a file before giving up
+const FILE_CREATE_ATTEMPTS: usize = 1024;
+
+/// Configuration file RAII guard which deletes it on completion
+#[derive(Debug)]
+pub struct ConfigFile {
+    /// Path to the config file
+    path: PathBuf,
+}
+
+impl ConfigFile {
+    /// Create a config file by serializing it to the given location
+    pub fn create<C>(app_name: &OsStr, config: &C) -> Self
+    where
+        C: Serialize,
+    {
+        let (path, mut file) = Self::open(app_name);
+
+        let config_toml = toml::to_string_pretty(config)
+            .unwrap_or_else(|e| panic!("error serializing config as TOML: {}", e))
+            .into_bytes();
+
+        file.write_all(&config_toml)
+            .unwrap_or_else(|e| panic!("error writing config to {}: {}", path.display(), e));
+
+        Self { path }
+    }
+
+    /// Get path to the configuration file
+    pub fn path(&self) -> &Path {
+        self.path.as_ref()
+    }
+
+    /// Create a temporary filename for the config
+    fn open(app_name: &OsStr) -> (PathBuf, File) {
+        // TODO: fully `OsString`-based path building
+        let filename_prefix = app_name.to_string_lossy().to_string()
+            + &Utc::now().format("-%Y-%m-%d-%H%M%S").to_string();
+
+        for n in 0..FILE_CREATE_ATTEMPTS {
+            let filename = if n == 0 {
+                format!("{}.toml", &filename_prefix)
+            } else {
+                format!("{}-{}.toml", &filename_prefix, n)
+            };
+
+            let path = env::temp_dir().join(filename);
+
+            match OpenOptions::new().write(true).create_new(true).open(&path) {
+                Ok(file) => return (path, file),
+                Err(e) => {
+                    if e.kind() == io::ErrorKind::AlreadyExists {
+                        continue;
+                    } else {
+                        panic!("couldn't create {}: {}", path.display(), e);
+                    }
+                }
+            }
+        }
+
+        panic!(
+            "couldn't create {}.toml after {} attempts!",
+            filename_prefix, FILE_CREATE_ATTEMPTS
+        )
+    }
+}
+
+impl Drop for ConfigFile {
+    fn drop(&mut self) {
+        fs::remove_file(&self.path).unwrap_or_else(|e| {
+            eprintln!("error removing {}: {}", self.path.display(), e);
+        })
+    }
+}

--- a/tests/app/exit_status.rs
+++ b/tests/app/exit_status.rs
@@ -1,5 +1,8 @@
 //! Tests for different exit status codes for different usage patterns
 
+#![deny(warnings, missing_docs, trivial_casts, unused_qualifications)]
+#![forbid(unsafe_code)]
+
 use abscissa::testing::CmdRunner;
 use lazy_static::lazy_static;
 

--- a/tests/app/metadata.rs
+++ b/tests/app/metadata.rs
@@ -1,5 +1,8 @@
 //! Tests to ensure generated app metadata is correct
 
+#![deny(warnings, missing_docs, trivial_casts, unused_qualifications)]
+#![forbid(unsafe_code)]
+
 #[test]
 fn crate_name() {
     assert_eq!(env!("CARGO_PKG_NAME"), "abscissa_gen_test_app");


### PR DESCRIPTION
Changes the bounds on `abscissa::Config` so `Default` is now required.

Uses the default configuration value when none has been provided.