### PR TITLE
testing: Add Regex newtype

### DIFF
--- a/abscissa_generator/template/tests/acceptance.rs.hbs
+++ b/abscissa_generator/template/tests/acceptance.rs.hbs
@@ -75,3 +75,11 @@ fn start_with_config_and_args() {
     cmd.stdout().expect_line("Hello, acceptance test!");
     cmd.wait().unwrap().expect_success();
 }
+
+/// Example of a test which matches a regular expression
+#[test]
+fn version_no_args() {
+    let mut runner = RUNNER.clone();
+    let mut cmd = runner.arg("version").capture_stdout().run();
+    cmd.stdout().expect_regex(r"\A\w+ [\d\.\-]+\z");
+}

--- a/src/testing.rs
+++ b/src/testing.rs
@@ -11,6 +11,7 @@
 mod config;
 pub mod prelude;
 pub mod process;
+mod regex;
 mod runner;
 
-pub use self::runner::CmdRunner;
+pub use self::{regex::Regex, runner::CmdRunner};

--- a/src/testing/process/streams.rs
+++ b/src/testing/process/streams.rs
@@ -1,6 +1,6 @@
 //! Streams (i.e. pipes) for communicating with a subprocess
 
-use regex::Regex;
+use crate::testing::Regex;
 use std::{
     io::{self, BufRead, BufReader},
     ops::{Deref, DerefMut},
@@ -34,16 +34,18 @@ where
     /// Read a line and test it against the given regex.
     ///
     /// Panics if the line does not match the regex.
-    fn expect_regex(&mut self, regex: &str) {
-        let r = Regex::new(regex)
-            .unwrap_or_else(|e| panic!("error compiling regex {:?}: {}", regex, e));
+    fn expect_regex<T>(&mut self, regex: T)
+    where
+        T: Into<Regex>,
+    {
+        let regex: Regex = regex.into();
 
         let mut line = String::new();
         self.read_line(&mut line)
             .unwrap_or_else(|e| panic!("error reading line from {}: {}", stringify!($name), e));
 
         assert!(
-            r.is_match(line.trim_end_matches('\n')),
+            regex.is_match(line.trim_end_matches('\n')),
             "regex {:?} did not match line: {:?}",
             regex,
             line

--- a/src/testing/regex.rs
+++ b/src/testing/regex.rs
@@ -1,0 +1,43 @@
+//! Regex newtype for simplifying conversions from the `regex` crate
+
+use std::{fmt, ops::Deref};
+
+/// Regex newtype (wraps `regex::Regex`)
+#[derive(Clone)]
+pub struct Regex(regex::Regex);
+
+impl Regex {
+    /// Compile a regular expression
+    pub fn new(re: &str) -> Result<Self, regex::Error> {
+        regex::Regex::new(re).map(Regex)
+    }
+}
+
+impl From<regex::Regex> for Regex {
+    fn from(re: regex::Regex) -> Regex {
+        Regex(re)
+    }
+}
+
+impl From<&str> for Regex {
+    fn from(re: &str) -> Regex {
+        let re_compiled = regex::Regex::new(re)
+            .unwrap_or_else(|err| panic!("error compiling regex: {} ({})", re, err));
+
+        Regex(re_compiled)
+    }
+}
+
+impl Deref for Regex {
+    type Target = regex::Regex;
+
+    fn deref(&self) -> &regex::Regex {
+        &self.0
+    }
+}
+
+impl fmt::Debug for Regex {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        fmt::Display::fmt(&self.0, f)
+    }
+}


### PR DESCRIPTION
Eliminates "stringly" typed Regex API by using a new type with `From` impls appropriate to the testing use case.