### PR TITLE
generator: Remove hashbrown dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -42,7 +42,6 @@ version = "0.2.0-rc.0"
 dependencies = [
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "handlebars 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "hashbrown 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/abscissa_generator/Cargo.toml
+++ b/abscissa_generator/Cargo.toml
@@ -17,7 +17,6 @@ travis-ci = { repository = "iqlusioninc/abscissa", branch = "develop" }
 [dependencies]
 failure = "0.1"
 handlebars = "2"
-hashbrown = "0.5"
 heck = "0.3"
 log = "0.4"
 semver = { version = "0.9", features = ["serde"] }

--- a/abscissa_generator/src/template/collection.rs
+++ b/abscissa_generator/src/template/collection.rs
@@ -73,7 +73,14 @@ impl Collection {
 
     /// Iterate over the templates in the collection
     pub fn iter(&self) -> Iter {
-        Iter::new(self.0.get_templates().iter())
+        // TODO: better way of constructing this `Iter`
+        Iter::new(
+            self.0
+                .get_templates()
+                .iter()
+                .map(|(path, template)| Template::new(path.as_ref(), template))
+                .collect(),
+        )
     }
 
     /// Render a template

--- a/abscissa_generator/src/template/iter.rs
+++ b/abscissa_generator/src/template/iter.rs
@@ -1,16 +1,19 @@
 //! Template iterator
 
 use super::Template;
-use hashbrown::hash_map;
-
-type HandlebarsIter<'a> = hash_map::Iter<'a, String, handlebars::Template>;
 
 /// Iterator over all registered template files
-pub struct Iter<'a>(HandlebarsIter<'a>);
+pub struct Iter<'a> {
+    /// Template collection
+    // TODO(tarcieri): less hacky implementation
+    templates: std::vec::IntoIter<Template<'a>>,
+}
 
 impl<'a> Iter<'a> {
-    pub(super) fn new(templates: HandlebarsIter<'a>) -> Self {
-        Iter(templates)
+    pub(super) fn new(templates: Vec<Template<'a>>) -> Self {
+        Iter {
+            templates: templates.into_iter(),
+        }
     }
 }
 
@@ -18,8 +21,6 @@ impl<'a> Iterator for Iter<'a> {
     type Item = Template<'a>;
 
     fn next(&mut self) -> Option<Template<'a>> {
-        self.0
-            .next()
-            .map(|(path, template)| Template::new(path.as_ref(), template))
+        self.templates.next()
     }
 }


### PR DESCRIPTION
handlebars 2.0.0 -> 2.0.1 upgraded `hashbrown` versions from 0.4 to 0.5 and in doing so broke the Abscissa v0.1 release, which now has an older incompatible v0.4. I've opened an upstream issue about this here:

https://github.com/sunng87/handlebars-rust/issues/279

To avoid this in the future, this change removes the external dependency. The implementation is a bit hacky, but gets the job done.