### PR TITLE
v0.2.0

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,15 @@
+## [0.2.0] (2019-07-16)
+
+- Merge `abscissa_generator` into `abscissa` CLI crate ([#95])
+- Rename `abscissa` crate to `abscissa_core` ([#94])
+- generator: Remove `hashbrown` dependency ([#93])
+- testing: Add Regex newtype ([#91])
+- config: Mandate `Default` bound + testing support ([#84], [#90])
+- generator: Add `serde(deny_unknown_fields)` ([#88])
+- generator: Add config filename boilerplate to template ([#82])
+- Configuration loading improvements ([#81])
+- Refactor and improve `abscissa::testing` ([#78])
+
 ## [0.1.0] (2019-07-02)
 
 - components: Add basic downcasting support ([#72])
@@ -57,6 +69,17 @@
 
 - Initial release
 
+[0.2.0]: https://github.com/iqlusioninc/abscissa/pull/96
+[#95]: https://github.com/iqlusioninc/abscissa/pull/95
+[#94]: https://github.com/iqlusioninc/abscissa/pull/94
+[#93]: https://github.com/iqlusioninc/abscissa/pull/93
+[#91]: https://github.com/iqlusioninc/abscissa/pull/91
+[#84]: https://github.com/iqlusioninc/abscissa/pull/84
+[#90]: https://github.com/iqlusioninc/abscissa/pull/90
+[#88]: https://github.com/iqlusioninc/abscissa/pull/88
+[#82]: https://github.com/iqlusioninc/abscissa/pull/82
+[#81]: https://github.com/iqlusioninc/abscissa/pull/81
+[#78]: https://github.com/iqlusioninc/abscissa/pull/78
 [0.1.0]: https://github.com/iqlusioninc/abscissa/pull/77
 [#72]: https://github.com/iqlusioninc/abscissa/pull/72
 [#71]: https://github.com/iqlusioninc/abscissa/pull/71

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2,9 +2,9 @@
 # It is not intended for manual editing.
 [[package]]
 name = "abscissa"
-version = "0.2.0-rc.1"
+version = "0.2.0"
 dependencies = [
- "abscissa_core 0.2.0-rc.1",
+ "abscissa_core 0.2.0",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "gumdrop 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "handlebars 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -15,9 +15,9 @@ dependencies = [
 
 [[package]]
 name = "abscissa_core"
-version = "0.2.0-rc.1"
+version = "0.2.0"
 dependencies = [
- "abscissa_derive 0.2.0-rc.1",
+ "abscissa_derive 0.2.0",
  "canonical-path 2.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "abscissa_derive"
-version = "0.2.0-rc.1"
+version = "0.2.0"
 dependencies = [
  "heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -5,7 +5,7 @@ description = """
               configuration, error handling, logging, and terminal interactions.
               This crate contains a CLI utility for generating new applications.
               """
-version     = "0.2.0-rc.1" # Also update html_root_url in lib.rs when bumping this
+version     = "0.2.0" # Also update html_root_url in lib.rs when bumping this
 license     = "Apache-2.0"
 authors     = ["Tony Arcieri <tony@iqlusion.io>"]
 edition     = "2018"
@@ -27,10 +27,10 @@ lazy_static = "1"
 serde = { version = "1", features = ["serde_derive"] }
 
 [dependencies.abscissa_core]
-version = "0.2.0-rc.1"
+version = "0.2.0"
 path = "../core"
 
 [dev-dependencies.abscissa_core]
-version = "0.2.0-rc.1"
+version = "0.2.0"
 features = ["testing"]
 path = "../core"

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -8,7 +8,7 @@
 #![forbid(unsafe_code)]
 #![doc(
     html_logo_url = "https://www.iqlusion.io/img/github/iqlusioninc/abscissa/abscissa-sq.svg",
-    html_root_url = "https://docs.rs/abscissa_core/0.2.0-rc.1"
+    html_root_url = "https://docs.rs/abscissa_core/0.2.0"
 )]
 
 pub mod application;

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -5,7 +5,7 @@ description = """
               configuration, error handling, logging, and terminal interactions.
               This crate contains the framework's core functionality.
               """
-version     = "0.2.0-rc.1" # Also update html_root_url in lib.rs when bumping this
+version     = "0.2.0" # Also update html_root_url in lib.rs when bumping this
 license     = "Apache-2.0"
 authors     = ["Tony Arcieri <tony@iqlusion.io>"]
 edition     = "2018"
@@ -16,7 +16,7 @@ categories  = ["command-line-interface", "rust-patterns"]
 keywords    = ["abscissa", "cli", "application", "framework", "service"]
 
 [dependencies]
-abscissa_derive = { version = "0.2.0-rc.1", path = "../derive" }
+abscissa_derive = { version = "0.2.0", path = "../derive" }
 canonical-path = "2"
 chrono = { version = "0.4", optional = true, features = ["serde"] }
 failure = "0.1"

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -90,7 +90,7 @@
 #![forbid(unsafe_code)]
 #![doc(
     html_logo_url = "https://www.iqlusion.io/img/github/iqlusioninc/abscissa/abscissa-sq.svg",
-    html_root_url = "https://docs.rs/abscissa_core/0.2.0-rc.1"
+    html_root_url = "https://docs.rs/abscissa_core/0.2.0"
 )]
 
 /// Abscissa version

--- a/derive/Cargo.toml
+++ b/derive/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name        = "abscissa_derive"
 description = "Custom derive support for the abscissa application microframework"
-version     = "0.2.0-rc.1" # Also update html_root_url in lib.rs when bumping this
+version     = "0.2.0" # Also update html_root_url in lib.rs when bumping this
 license     = "Apache-2.0"
 authors     = ["Tony Arcieri <tony@iqlusion.io>"]
 edition     = "2018"

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -5,7 +5,7 @@
 #![forbid(unsafe_code)]
 #![doc(
     html_logo_url = "https://www.iqlusion.io/img/github/iqlusioninc/abscissa/abscissa-sq.svg",
-    html_root_url = "https://docs.rs/abscissa_derive/0.2.0-rc.1"
+    html_root_url = "https://docs.rs/abscissa_derive/0.2.0"
 )]
 
 extern crate proc_macro;


### PR DESCRIPTION
- Merge `abscissa_generator` into `abscissa` CLI crate (#95)
- Rename `abscissa` crate to `abscissa_core` (#94)
- generator: Remove `hashbrown` dependency (#93)
- testing: Add Regex newtype (#91)
- config: Mandate `Default` bound + testing support (#84, #90)
- generator: Add `serde(deny_unknown_fields)` (#88)
- generator: Add config filename boilerplate to template (#82)
- Configuration loading improvements (#81)
- Refactor and improve `abscissa::testing` (#78)