### PR TITLE
Bugfix: allow Registry::iter() without mutable reference

### DIFF
--- a/core/src/component/registry.rs
+++ b/core/src/component/registry.rs
@@ -72,8 +72,8 @@ where
         Ok(())
     }
 
-    /// Iterate over the components mutably.
-    pub fn iter(&mut self) -> slice::Iter<Box<dyn Component<A>>> {
+    /// Iterate over the components.
+    pub fn iter(&self) -> slice::Iter<Box<dyn Component<A>>> {
         self.components.iter()
     }
 


### PR DESCRIPTION
Fixes #109 