### PR TITLE
Initial component tests

### DIFF
--- a/core/src/component/id.rs
+++ b/core/src/component/id.rs
@@ -15,7 +15,7 @@ pub struct Id(&'static str);
 impl Id {
     /// Create a new component identifier
     // TODO(tarcieri): make this method private in the future
-    pub fn new(id: &'static str) -> Id {
+    pub const fn new(id: &'static str) -> Id {
         Id(id)
     }
 }

--- a/core/src/component/registry.rs
+++ b/core/src/component/registry.rs
@@ -117,13 +117,22 @@ where
         Ok(())
     }
 
+    /// Get the number of currently registered components
+    pub fn len(&self) -> usize {
+        self.components.len()
+    }
+
+    /// Is the registry empty?
+    pub fn is_empty(&self) -> bool {
+        self.components.is_empty()
+    }
+
     /// Get a component reference by its handle
     pub fn get(&self, handle: Handle) -> Option<&dyn Component<A>> {
         self.components.get(handle.index).map(AsRef::as_ref)
     }
 
     /// Get a mutable component reference by its handle
-    #[allow(clippy::borrowed_box)]
     pub fn get_mut(&mut self, handle: Handle) -> Option<&mut (dyn Component<A> + 'static)> {
         self.components.get_mut(handle.index).map(AsMut::as_mut)
     }
@@ -139,7 +148,6 @@ where
     }
 
     /// Get a mutable component ref by its ID
-    #[allow(clippy::borrowed_box)]
     pub fn get_mut_by_id(&mut self, id: Id) -> Option<&mut (dyn Component<A> + 'static)> {
         self.get_mut(self.get_handle_by_id(id)?)
     }

--- a/core/src/logging/component.rs
+++ b/core/src/logging/component.rs
@@ -5,6 +5,9 @@
 use super::{config::Config, logger};
 use crate::{component, Application, Component, FrameworkError, Version};
 
+/// Lopgging component ID
+pub const ID: component::Id = component::Id::new("abscissa_core::logging::LoggingComponent");
+
 /// Abscissa component for initializing the logging subsystem
 #[derive(Debug, Default)]
 pub struct LoggingComponent {
@@ -26,7 +29,7 @@ where
 {
     /// Name of this component
     fn id(&self) -> component::Id {
-        component::Id::new("abscissa_core::logging")
+        ID
     }
 
     /// Version of this component

--- a/core/src/terminal/component.rs
+++ b/core/src/terminal/component.rs
@@ -5,6 +5,9 @@ use crate::{component, Application, Component, FrameworkError, Version};
 use std::fmt;
 use termcolor::ColorChoice;
 
+/// Terminal component ID
+pub const ID: component::Id = component::Id::new("abscissa_core::terminal::TerminalComponent");
+
 /// Abscissa terminal subsystem component
 pub struct TerminalComponent {}
 
@@ -21,9 +24,9 @@ impl<A> Component<A> for TerminalComponent
 where
     A: Application,
 {
-    /// Name of this component
+    /// ID for this component
     fn id(&self) -> component::Id {
-        component::Id::new("abscissa_core::terminal")
+        ID
     }
 
     /// Version of this component

--- a/core/tests/component.rs
+++ b/core/tests/component.rs
@@ -1,0 +1,50 @@
+//! Tests for Abscissa's component functionality
+
+mod example_app;
+
+use self::example_app::{ExampleApp, ExampleConfig};
+use abscissa_core::{component, Component, FrameworkError, Version};
+
+/// ID for `FooComponent`
+const FOO_COMPONENT_ID: component::Id = component::Id::new("FooComponent");
+
+/// Example component
+#[derive(Clone, Debug, Default)]
+pub struct FooComponent {
+    /// Component state
+    pub state: Option<String>,
+}
+
+impl FooComponent {
+    /// Set the state string to a particular value
+    pub fn set_state(&mut self, state_str: &str) {
+        self.state = Some(state_str.to_owned());
+    }
+}
+
+impl Component<ExampleApp> for FooComponent {
+    fn id(&self) -> component::Id {
+        FOO_COMPONENT_ID
+    }
+
+    fn version(&self) -> Version {
+        Version::new(0, 0, 0)
+    }
+
+    fn after_config(&mut self, _config: &ExampleConfig) -> Result<(), FrameworkError> {
+        Ok(())
+    }
+}
+
+#[test]
+fn component_registration() {
+    let mut registry = component::Registry::default();
+    assert!(registry.is_empty());
+
+    let component = Box::new(FooComponent::default()) as Box<dyn Component<ExampleApp>>;
+    registry.register(vec![component]).unwrap();
+    assert!(!registry.is_empty());
+
+    let foo = registry.get_by_id(FOO_COMPONENT_ID).unwrap();
+    assert_eq!(foo.id(), FOO_COMPONENT_ID);
+}

--- a/core/tests/example_app/mod.rs
+++ b/core/tests/example_app/mod.rs
@@ -1,0 +1,61 @@
+//! Example application used for testing purposes
+
+use abscissa_core::{
+    application, Application, Command, Config, Configurable, FrameworkError, Options, Runnable,
+    StandardPaths,
+};
+use serde::{Deserialize, Serialize};
+use std::path::PathBuf;
+
+#[derive(Clone, Config, Debug, Default, Deserialize, Serialize)]
+pub struct ExampleConfig {}
+
+#[derive(Command, Debug, Options)]
+pub struct ExampleCommand {}
+
+impl Configurable<ExampleConfig> for ExampleCommand {
+    fn config_path(&self) -> Option<PathBuf> {
+        None
+    }
+}
+
+impl Runnable for ExampleCommand {
+    fn run(&self) {
+        unimplemented!();
+    }
+}
+
+#[derive(Debug, Default)]
+pub struct ExampleApp {
+    config: Option<ExampleConfig>,
+    state: application::State<Self>,
+}
+
+impl Application for ExampleApp {
+    type Cmd = ExampleCommand;
+    type Cfg = ExampleConfig;
+    type Paths = StandardPaths;
+
+    fn config(&self) -> &ExampleConfig {
+        unimplemented!();
+    }
+
+    fn state(&self) -> &application::State<Self> {
+        unimplemented!();
+    }
+
+    fn state_mut(&mut self) -> &mut application::State<Self> {
+        unimplemented!();
+    }
+
+    fn register_components(&mut self, command: &Self::Cmd) -> Result<(), FrameworkError> {
+        let components = self.framework_components(command)?;
+        self.state.components.register(components)
+    }
+
+    fn after_config(&mut self, config: Self::Cfg) -> Result<(), FrameworkError> {
+        self.state.components.after_config(&config)?;
+        self.config = Some(config);
+        Ok(())
+    }
+}


### PR DESCRIPTION
Adds a set of tests to `abscissa_core` for basic component registry behaviors like registering components and getting registered components.