### PR TITLE
component: Add `get_downcast_ref`/`get_downcast_mut` to Registry

### DIFF
--- a/core/src/component.rs
+++ b/core/src/component.rs
@@ -8,7 +8,7 @@ mod registry;
 
 pub use self::{handle::Handle, id::Id, registry::Registry};
 use crate::{application::Application, error::FrameworkError, shutdown::Shutdown, Version};
-use std::{cmp::Ordering, fmt::Debug, slice::Iter};
+use std::{any::Any, cmp::Ordering, fmt::Debug, slice::Iter};
 
 /// Application components.
 ///
@@ -22,7 +22,7 @@ use std::{cmp::Ordering, fmt::Debug, slice::Iter};
 ///
 /// Additionally, they receive a callback prior to application shutdown.
 // TODO(tarcieri): downcast support for accessing components as concrete types?
-pub trait Component<A>: Debug + Send + Sync
+pub trait Component<A>: AsAny + Debug + Send + Sync
 where
     A: Application,
 {
@@ -85,5 +85,25 @@ where
         } else {
             Some(Ordering::Equal)
         }
+    }
+}
+
+/// Trait used to downcast trait objects back to their concrete types
+// TODO(tarcieri): eliminate this trait or hide it from the public API
+pub trait AsAny: Any {
+    /// Borrow this concrete type as a `&dyn Any`
+    fn as_any(&self) -> &dyn Any;
+
+    /// Borrow this concrete type as a `&mut dyn Any`
+    fn as_mut_any(&mut self) -> &mut dyn Any;
+}
+
+impl<T: Any> AsAny for T {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn as_mut_any(&mut self) -> &mut dyn Any {
+        self
     }
 }

--- a/core/src/component/registry.rs
+++ b/core/src/component/registry.rs
@@ -136,7 +136,6 @@ where
     pub fn get_mut(&mut self, handle: Handle) -> Option<&mut (dyn Component<A> + 'static)> {
         self.components.get_mut(handle.index).map(AsMut::as_mut)
     }
-
     /// Get a component's handle by its ID
     pub fn get_handle_by_id(&self, id: Id) -> Option<Handle> {
         Some(Handle::new(id, *self.index_map.get(&id)?))
@@ -169,5 +168,40 @@ where
         }
 
         Ok(())
+    }
+}
+
+impl<A> Registry<A>
+where
+    A: Application + 'static,
+{
+    /// Get a component reference by its type
+    pub fn get_downcast_ref<C>(&self) -> Option<&C>
+    where
+        C: Component<A>,
+    {
+        // TODO(tarcieri): index components by `TypeId` for faster lookup
+        for (_, box_component) in &self.components {
+            if let Some(component) = (*(*box_component)).as_any().downcast_ref::<C>() {
+                return Some(component);
+            }
+        }
+
+        None
+    }
+
+    /// Get a mutable component reference by its type
+    pub fn get_downcast_mut<C>(&mut self) -> Option<&mut C>
+    where
+        C: Component<A>,
+    {
+        // TODO(tarcieri): index components by `TypeId` for faster lookup
+        for (_, box_component) in &mut self.components {
+            if let Some(component) = (*(*box_component)).as_mut_any().downcast_mut::<C>() {
+                return Some(component);
+            }
+        }
+
+        None
     }
 }

--- a/core/tests/component.rs
+++ b/core/tests/component.rs
@@ -48,3 +48,20 @@ fn component_registration() {
     let foo = registry.get_by_id(FOO_COMPONENT_ID).unwrap();
     assert_eq!(foo.id(), FOO_COMPONENT_ID);
 }
+
+#[test]
+fn get_downcast_ref() {
+    let mut registry = component::Registry::default();
+    let component = Box::new(FooComponent::default()) as Box<dyn Component<ExampleApp>>;
+    registry.register(vec![component]).unwrap();
+
+    {
+        let foo_mut = registry.get_downcast_mut::<FooComponent>().unwrap();
+        foo_mut.set_state("mutated!");
+    }
+
+    {
+        let foo = registry.get_downcast_ref::<FooComponent>().unwrap();
+        assert_eq!(foo.state.as_ref().unwrap(), "mutated!");
+    }
+}


### PR DESCRIPTION
Support for getting concrete types from the component registry.

This presently doesn't ensure types are unique, or index them by their `TypeId`, but these things would probably be good ideas.