### PR TITLE
component: Index Registry by TypeId

### DIFF
--- a/core/src/application.rs
+++ b/core/src/application.rs
@@ -34,7 +34,7 @@ use std::{env, path::Path, process, vec};
 /// - `Config `: application configuration
 /// - `Paths`: paths to various resources within the application
 #[allow(unused_variables)]
-pub trait Application: Default + Sized {
+pub trait Application: Default + Sized + 'static {
     /// Application (sub)command which serves as the main entry point.
     type Cmd: Command + Configurable<Self::Cfg>;
 

--- a/core/src/application/state.rs
+++ b/core/src/application/state.rs
@@ -4,7 +4,7 @@ use crate::{application::Application, component, thread};
 
 /// Framework-managed application state
 #[derive(Debug, Default)]
-pub struct State<A: Application> {
+pub struct State<A: Application + 'static> {
     /// Application components.
     pub components: component::Registry<A>,
 

--- a/core/src/component.rs
+++ b/core/src/component.rs
@@ -88,7 +88,7 @@ where
     }
 }
 
-/// Trait used to downcast trait objects back to their concrete types
+/// Dynamic type helper trait
 // TODO(tarcieri): eliminate this trait or hide it from the public API
 pub trait AsAny: Any {
     /// Borrow this concrete type as a `&dyn Any`
@@ -98,7 +98,10 @@ pub trait AsAny: Any {
     fn as_mut_any(&mut self) -> &mut dyn Any;
 }
 
-impl<T: Any> AsAny for T {
+impl<T> AsAny for T
+where
+    T: Any,
+{
     fn as_any(&self) -> &dyn Any {
         self
     }


### PR DESCRIPTION
Adds a secondary TypeId index which can be used to look components up by type, rather than iterating over all registered components and trying to downcast them.

This will also ensure that only one instance of each component type is allowed to be registered.

Adding this requires a `'static` bound on the component registry's application type.