### PR TITLE
derive: Custom derive support for `Component`

### DIFF
--- a/core/src/command.rs
+++ b/core/src/command.rs
@@ -5,6 +5,9 @@ mod help;
 mod usage;
 
 pub use self::{entrypoint::EntryPoint, help::Help, usage::Usage};
+#[doc(hidden)]
+pub use abscissa_derive::Command;
+
 use crate::{runnable::Runnable, terminal};
 use gumdrop::Options;
 use std::fmt::Debug;

--- a/core/src/component.rs
+++ b/core/src/component.rs
@@ -1,4 +1,6 @@
-//! Application components.
+//! Application components: extensions/plugins for Abscissa applications.
+//!
+//! See docs on the `Component` trait for more information.
 
 #![allow(unused_variables)]
 
@@ -7,6 +9,9 @@ mod id;
 mod registry;
 
 pub use self::{handle::Handle, id::Id, registry::Registry};
+#[doc(hidden)]
+pub use abscissa_derive::Component;
+
 use crate::{application::Application, error::FrameworkError, shutdown::Shutdown, Version};
 use std::{any::Any, cmp::Ordering, fmt::Debug, slice::Iter};
 
@@ -18,10 +23,25 @@ use std::{any::Any, cmp::Ordering, fmt::Debug, slice::Iter};
 /// and can (potentially in the future) support runtime reinitialization.
 ///
 /// During application initialization, callbacks are sent to all components
-/// upon events like application configuration being loaded.
+/// upon events like application configuration being loaded. The
+/// `register_dependency` callback is called for each dependency returned
+/// by the `dependencies` method.
 ///
 /// Additionally, they receive a callback prior to application shutdown.
-// TODO(tarcieri): downcast support for accessing components as concrete types?
+///
+/// ## Custom Derive
+///
+/// The main intended way to impl this trait is by using the built-in custom
+/// derive functionality.
+///
+/// ```rust
+/// use abscissa_core::Component;
+///
+/// #[derive(Component, Debug)]
+/// pub struct MyComponent {}
+/// ```
+///
+/// This will automatically implement the entire trait for you.
 pub trait Component<A>: AsAny + Debug + Send + Sync
 where
     A: Application,

--- a/core/src/config.rs
+++ b/core/src/config.rs
@@ -5,12 +5,13 @@ mod overrides;
 mod reader;
 
 pub use self::{configurable::Configurable, overrides::Override, reader::Reader};
+#[doc(hidden)]
+pub use abscissa_derive::Config;
+
 use crate::{
     error::{FrameworkError, FrameworkErrorKind::ConfigError},
     path::AbsPath,
 };
-#[doc(hidden)]
-pub use abscissa_derive::Config;
 use serde::de::DeserializeOwned;
 use std::{fmt::Debug, fs::File, io::Read};
 

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -133,8 +133,6 @@ pub mod thread;
 
 // Proc macros
 
-#[doc(hidden)]
-pub use abscissa_derive::{Command, Runnable};
 #[cfg(feature = "options")]
 pub use gumdrop::Options;
 

--- a/core/src/logging/component.rs
+++ b/core/src/logging/component.rs
@@ -3,13 +3,11 @@
 // TODO(tarcieri): logfile support?
 
 use super::{config::Config, logger};
-use crate::{component, Application, Component, FrameworkError, Version};
-
-/// Lopgging component ID
-pub const ID: component::Id = component::Id::new("abscissa_core::logging::LoggingComponent");
+use crate::{Component, FrameworkError};
 
 /// Abscissa component for initializing the logging subsystem
-#[derive(Debug, Default)]
+#[derive(Component, Debug, Default)]
+#[component(core)]
 pub struct LoggingComponent {
     config: Config,
 }
@@ -19,27 +17,5 @@ impl LoggingComponent {
     pub fn new(config: Config) -> Result<Self, FrameworkError> {
         logger::init(&config);
         Ok(Self { config })
-    }
-}
-
-// TODO: shutdown handler?
-impl<A> Component<A> for LoggingComponent
-where
-    A: Application,
-{
-    /// Name of this component
-    fn id(&self) -> component::Id {
-        ID
-    }
-
-    /// Version of this component
-    fn version(&self) -> Version {
-        Version::new(0, 0, 0)
-    }
-
-    /// Initialize this component at the time the framework boots
-    fn after_config(&mut self, _config: &A::Cfg) -> Result<(), FrameworkError> {
-        // TODO(tarcieri): set logging configuration here instead of earlier?
-        Ok(())
     }
 }

--- a/core/src/runnable.rs
+++ b/core/src/runnable.rs
@@ -1,5 +1,8 @@
 //! `Runnable` trait.
 
+#[doc(hidden)]
+pub use abscissa_derive::Runnable;
+
 /// `Runnable` is a common trait for things which can be run without any
 /// arguments.
 ///

--- a/core/src/terminal/component.rs
+++ b/core/src/terminal/component.rs
@@ -1,14 +1,13 @@
 //! Terminal component
 
 use super::stream;
-use crate::{component, Application, Component, FrameworkError, Version};
+use crate::Component;
 use std::fmt;
 use termcolor::ColorChoice;
 
-/// Terminal component ID
-pub const ID: component::Id = component::Id::new("abscissa_core::terminal::TerminalComponent");
-
 /// Abscissa terminal subsystem component
+#[derive(Component)]
+#[component(core)]
 pub struct TerminalComponent {}
 
 impl TerminalComponent {
@@ -17,26 +16,6 @@ impl TerminalComponent {
         // TODO(tarcieri): handle terminal reinit (without panicing)
         stream::set_color_choice(color_choice);
         Self {}
-    }
-}
-
-impl<A> Component<A> for TerminalComponent
-where
-    A: Application,
-{
-    /// ID for this component
-    fn id(&self) -> component::Id {
-        ID
-    }
-
-    /// Version of this component
-    fn version(&self) -> Version {
-        Version::new(0, 0, 0)
-    }
-
-    /// Initialize this component at the time the framework boots
-    fn after_config(&mut self, _config: &A::Cfg) -> Result<(), FrameworkError> {
-        Ok(())
     }
 }
 

--- a/core/tests/component.rs
+++ b/core/tests/component.rs
@@ -2,14 +2,14 @@
 
 mod example_app;
 
-use self::example_app::{ExampleApp, ExampleConfig};
-use abscissa_core::{component, Component, FrameworkError, Version};
+use self::example_app::ExampleApp;
+use abscissa_core::{component, Component};
 
 /// ID for `FooComponent`
-const FOO_COMPONENT_ID: component::Id = component::Id::new("FooComponent");
+const FOO_COMPONENT_ID: component::Id = component::Id::new("component::FooComponent");
 
 /// Example component
-#[derive(Clone, Debug, Default)]
+#[derive(Component, Debug, Default)]
 pub struct FooComponent {
     /// Component state
     pub state: Option<String>,
@@ -22,26 +22,14 @@ impl FooComponent {
     }
 }
 
-impl Component<ExampleApp> for FooComponent {
-    fn id(&self) -> component::Id {
-        FOO_COMPONENT_ID
-    }
-
-    fn version(&self) -> Version {
-        Version::new(0, 0, 0)
-    }
-
-    fn after_config(&mut self, _config: &ExampleConfig) -> Result<(), FrameworkError> {
-        Ok(())
-    }
-}
-
 #[test]
 fn component_registration() {
     let mut registry = component::Registry::default();
     assert!(registry.is_empty());
 
     let component = Box::new(FooComponent::default()) as Box<dyn Component<ExampleApp>>;
+    assert_eq!(component.id(), FOO_COMPONENT_ID);
+
     registry.register(vec![component]).unwrap();
     assert!(!registry.is_empty());
 

--- a/derive/src/component.rs
+++ b/derive/src/component.rs
@@ -1,0 +1,134 @@
+//! Custom derive support for `abscissa_core::component::Component`.
+
+use proc_macro2::{Span, TokenStream};
+use quote::quote;
+use syn::{Attribute, Ident, Meta, NestedMeta};
+use synstructure::Structure;
+
+/// Ident name for component attributes
+const COMPONENT_IDENT: &str = "component";
+
+/// Custom derive for `abscissa_core::component::Component`
+pub fn derive_component(s: Structure) -> TokenStream {
+    let derive_attributes = DeriveAttributes::parse(&s);
+    let abscissa_core = derive_attributes.crate_name;
+    let name = &s.ast().ident;
+
+    s.gen_impl(quote! {
+        gen impl<A> Component<A> for @Self
+        where
+            A: #abscissa_core::Application
+        {
+            #[doc = "Identifier for this component"]
+            fn id(&self) -> #abscissa_core::component::Id {
+                // TODO(tarcieri): use `core::any::type_name` here when stable
+                #abscissa_core::component::Id::new(concat!(module_path!(), "::", stringify!(#name)))
+            }
+
+            #[doc = "Version of this component"]
+            fn version(&self) -> #abscissa_core::Version {
+                #abscissa_core::Version::parse(env!("CARGO_PKG_VERSION")).unwrap()
+            }
+        }
+    })
+}
+
+/// Derive attributes: parser for #[component(...)] attributes
+// TODO(tarcieri): replace this with e.g. `darling`?
+struct DeriveAttributes {
+    /// Crate name for `abscissa_core`.
+    ///
+    /// Workaround for using this custom derive in `abscissa_core` itself. See:
+    /// <https://github.com/rust-lang/rust/issues/54363>
+    crate_name: Ident,
+}
+
+impl Default for DeriveAttributes {
+    fn default() -> Self {
+        Self {
+            crate_name: Ident::new("abscissa_core", Span::call_site()),
+        }
+    }
+}
+
+impl DeriveAttributes {
+    /// Parse `#[component(...)]` attributes from the incoming AST
+    fn parse(s: &Structure) -> Self {
+        let mut result = Self::default();
+
+        for v in s.variants().iter() {
+            result.parse_attributes(v.ast().attrs);
+        }
+
+        result
+    }
+
+    /// Parse `#[component(...)]` attributes
+    fn parse_attributes(&mut self, attributes: &[Attribute]) {
+        for attr in attributes {
+            let meta = attr
+                .parse_meta()
+                .unwrap_or_else(|e| panic!("error parsing attribute: {} ({})", attr.tts, e));
+
+            if let Meta::List(list) = meta {
+                if list.ident != COMPONENT_IDENT {
+                    return;
+                }
+
+                for nested_meta in &list.nested {
+                    if let NestedMeta::Meta(Meta::Word(ident)) = nested_meta {
+                        self.parse_ident_attribute(ident);
+                    } else {
+                        panic!("malformed #[component] attribute: {:?}", nested_meta);
+                    }
+                }
+            }
+        }
+    }
+
+    /// Parse a `#[component(...)]` attribute containing a single ident (e.g. `core`)
+    fn parse_ident_attribute(&mut self, ident: &Ident) {
+        if ident == "core" {
+            self.crate_name = Ident::new("crate", Span::call_site());
+        } else {
+            panic!("unknown #[component] attribute type: {}", ident);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use synstructure::test_derive;
+
+    #[test]
+    fn derive_command_on_struct() {
+        test_derive! {
+            derive_component {
+                struct MyComponent {}
+            }
+            expands to {
+                #[allow(non_upper_case_globals)]
+                const _DERIVE_Component_A_FOR_MyComponent: () = {
+                    impl<A> Component<A> for MyComponent
+                    where
+                        A: abscissa_core::Application
+                    {
+                        #[doc = "Identifier for this component" ]
+                        fn id(&self) -> abscissa_core::component::Id {
+                            abscissa_core::component::Id::new(
+                                concat!(module_path!(), "::" , stringify!(MyComponent))
+                            )
+                        }
+
+                        #[doc = "Version of this component"]
+                        fn version(&self) -> abscissa_core::Version {
+                            abscissa_core::Version::parse(env!("CARGO_PKG_VERSION")).unwrap()
+                        }
+                    }
+                };
+            }
+            no_build // tests the code compiles are in the `abscissa` crate
+        }
+    }
+}

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -11,11 +11,13 @@
 extern crate proc_macro;
 
 mod command;
+mod component;
 mod config;
 mod runnable;
 
 use synstructure::decl_derive;
 
-decl_derive!([Command]  => command::derive_command);
-decl_derive!([Config]   => config::derive_config);
+decl_derive!([Command] => command::derive_command);
+decl_derive!([Component, attributes(component)] => component::derive_component);
+decl_derive!([Config] => config::derive_config);
 decl_derive!([Runnable] => runnable::derive_runnable);


### PR DESCRIPTION
Adds custom derive support for `Component` which computes the `component::Id` automatically and sources the `Version` from the current crate version.