### PR TITLE
component: Add #[dependencies(...)] attribute

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -40,6 +40,7 @@ dependencies = [
 name = "abscissa_derive"
 version = "0.3.0-rc.0"
 dependencies = [
+ "darling 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -142,6 +143,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "darling_core 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "darling_macro 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ident_case 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "strsim 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.42 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "darling_core 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.42 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "digest"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -172,6 +205,11 @@ dependencies = [
 [[package]]
 name = "fake-simd"
 version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "fnv"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -240,6 +278,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "unicode-segmentation 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "itoa"
@@ -480,6 +523,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "strsim"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "syn"
 version = "0.15.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -637,10 +685,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum cc 1.0.38 (registry+https://github.com/rust-lang/crates.io-index)" = "ce400c638d48ee0e9ab75aef7997609ec57367ccfe1463f21bf53c3eca67bf46"
 "checksum cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "b486ce3ccf7ffd79fdeb678eac06a9e6c09fc88d33836340becb8fffe87c5e33"
 "checksum chrono 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)" = "77d81f58b7301084de3b958691458a53c3f7e0b1d702f77e550b6a88e3a88abe"
+"checksum darling 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fcfbcb0c5961907597a7d1148e3af036268f2b773886b8bb3eeb1e1281d3d3d6"
+"checksum darling_core 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "6afc018370c3bff3eb51f89256a6bdb18b4fdcda72d577982a14954a7a0b402c"
+"checksum darling_macro 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c6d8dac1c6f1d29a41c4712b4400f878cb4fcc4c7628f298dd75038e024998d1"
 "checksum digest 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f3d0c8c8752312f9713efd397ff63acb9f85585afbf179282e720e7704954dd5"
 "checksum failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "795bd83d3abeb9220f257e597aa0080a508b27533824adf336529648f6abf7e2"
 "checksum failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "ea1063915fd7ef4309e222a5a07cf9c319fb9c7836b1f89b85458672dbb127e1"
 "checksum fake-simd 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e88a8acf291dafb59c2d96e8f59828f3838bb1a70398823ade51a84de6a6deed"
+"checksum fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "2fad85553e09a6f881f739c29f0b00b0f01357c743266d478b68951ce23285f3"
 "checksum generational-arena 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "4024f96ffa0ebaaf36aa589cd41f2fd69f3a5e6fd02c86e11e12cdf41d5b46a3"
 "checksum generic-array 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)" = "c68f0274ae0e023facc3c97b2e00f076be70e254bc851d972503b328db79b2ec"
 "checksum gumdrop 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7a57b4113bb9af093a1cd0b505a44a93103e32e258296d01fa2def3f37c2c7cc"
@@ -648,6 +700,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum handlebars 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "df044dd42cdb7e32f28557b661406fc0f2494be75199779998810dbc35030e0d"
 "checksum hashbrown 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e1de41fb8dba9714efd92241565cdff73f78508c95697dd56787d3cba27e2353"
 "checksum heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "20564e78d53d2bb135c343b3f47714a56af2061f1c928fdb541dc7b9fdd94205"
+"checksum ident_case 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 "checksum itoa 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "501266b7edd0174f8530248f87f99c88fbe60ca4ef3dd486835b8d8d53136f7f"
 "checksum lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bc5729f27f159ddd61f4df6228e827e86643d4d3e7c32183cb30a1c08f604a14"
 "checksum libc 0.2.60 (registry+https://github.com/rust-lang/crates.io-index)" = "d44e80633f007889c7eff624b709ab43c92d708caad982295768a7b13ca3b5eb"
@@ -679,6 +732,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum sha-1 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "23962131a91661d643c98940b20fcaffe62d776a823247be80a48fcb8b6fce68"
 "checksum signal-hook 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)" = "4f61c4d59f3aaa9f61bba6450a9b80ba48362fd7d651689e7a10c453b1f6dc68"
 "checksum signal-hook-registry 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "913661ac8848a61e39684a3c3e7a7a14a4deec7f54b4976d0641e70dda3939b1"
+"checksum strsim 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bb4f380125926a99e52bc279241539c018323fab05ad6368b56f93d9369ff550"
 "checksum syn 0.15.42 (registry+https://github.com/rust-lang/crates.io-index)" = "eadc09306ca51a40555dd6fc2b415538e9e18bc9f870e47b1a524a79fe2dcf5e"
 "checksum synstructure 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)" = "02353edf96d6e4dc81aea2d8490a7e9db177bf8acb0e951c24940bf866cb313f"
 "checksum termcolor 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "96d6098003bde162e4277c70665bd87c326f5a0c3f3fbfb285787fa482d54e6e"

--- a/README.md
+++ b/README.md
@@ -118,22 +118,23 @@ default set of features in the application:
 | 2  | [aho-corasick]    | [@BurntSushi]    | MIT/Unlicense  | Pattern-matching alg    |
 | 3  | [cc]              | [@alexcrichton]  | Apache-2.0/MIT | C/C++ compiler wrapper  |
 | 4  | [cfg-if]          | [@alexcrichton]  | Apache-2.0/MIT | If-like `#[cfg]` macros |
-| 5  | [failure_derive]  | [@withoutboats]  | Apache-2.0/MIT | failure custom derive   |
-| 6  | [gumdrop_derive]  | [@Murarth]       | Apache-2.0/MIT | Command-line options    |
-| 7  | [heck]            | [@withoutboats]  | Apache-2.0/MIT | Case conversion utils   |
-| 8  | [memchr]          | [@BurntSushi]    | MIT/Unlicense  | Optimize byte search    |
-| 9  | [proc-macro2]     | [@alexcrichton]  | Apache-2.0/MIT | Shim for Macros 2.0 API |
-| 10 | [quote]           | [@dtolnay]       | Apache-2.0/MIT | Rust AST to token macro |
-| 11 | [regex]           | [rust-lang]      | Apache-2.0/MIT | Regular expressions     |
-| 12 | [regex-syntax]    | [rust-lang]      | Apache-2.0/MIT | Regex syntax impl       |
-| 13 | [serde_derive]    | [serde-rs]       | Apache-2.0/MIT | `serde` custom derive   |
-| 14 | [syn]             | [@dtolnay]       | Apache-2.0/MIT | Rust source code parser |
-| 15 | [synstructure]    | [@mystor]        | Apache-2.0/MIT | `syn` structure macros  |
-| 16 | [thread_local]    | [@Amanieu]       | Apache-2.0/MIT | Per-object thread local |
-| 17 | [ucd-util]        | [@BurntSushi]    | Apache-2.0/MIT | Unicode utilities       |
-| 18 | [unicode-xid]     | [unicode-rs]     | Apache-2.0/MIT | Identify valid Unicode  |
-| 19 | [utf8-ranges]     | [@BurntSushi]    | MIT/Unlicense  | UTF-8 codepoint ranges  |
-| 20 | [wait-timeout]    | [@alexcrichton]  | Apache-2.0/MIT | Timeouts for waitpid    |
+| 5  | [darling]         | [@TedDriggs]     | MIT            | Nifty attribute parser  |
+| 6  | [failure_derive]  | [@withoutboats]  | Apache-2.0/MIT | failure custom derive   |
+| 7  | [gumdrop_derive]  | [@Murarth]       | Apache-2.0/MIT | Command-line options    |
+| 8  | [heck]            | [@withoutboats]  | Apache-2.0/MIT | Case conversion utils   |
+| 9  | [memchr]          | [@BurntSushi]    | MIT/Unlicense  | Optimize byte search    |
+| 10 | [proc-macro2]     | [@alexcrichton]  | Apache-2.0/MIT | Shim for Macros 2.0 API |
+| 11 | [quote]           | [@dtolnay]       | Apache-2.0/MIT | Rust AST to token macro |
+| 12 | [regex]           | [rust-lang]      | Apache-2.0/MIT | Regular expressions     |
+| 13 | [regex-syntax]    | [rust-lang]      | Apache-2.0/MIT | Regex syntax impl       |
+| 14 | [serde_derive]    | [serde-rs]       | Apache-2.0/MIT | `serde` custom derive   |
+| 15 | [syn]             | [@dtolnay]       | Apache-2.0/MIT | Rust source code parser |
+| 16 | [synstructure]    | [@mystor]        | Apache-2.0/MIT | `syn` structure macros  |
+| 17 | [thread_local]    | [@Amanieu]       | Apache-2.0/MIT | Per-object thread local |
+| 18 | [ucd-util]        | [@BurntSushi]    | Apache-2.0/MIT | Unicode utilities       |
+| 19 | [unicode-xid]     | [unicode-rs]     | Apache-2.0/MIT | Identify valid Unicode  |
+| 20 | [utf8-ranges]     | [@BurntSushi]    | MIT/Unlicense  | UTF-8 codepoint ranges  |
+| 21 | [wait-timeout]    | [@alexcrichton]  | Apache-2.0/MIT | Timeouts for waitpid    |
 
 ### Dependency Relationships
 
@@ -323,6 +324,7 @@ read the [CONTRIBUTING.md] and [CODE_OF_CONDUCT.md] files first.
 [cc]: https://crates.io/crates/cc
 [cfg-if]: https://crates.io/crates/cfg-if
 [chrono]: https://crates.io/crates/chrono
+[darling]: https://github.com/TedDriggs/darling
 [failure]: https://crates.io/crates/failure
 [failure_derive]: https://crates.io/crates/failure_derive
 [generational-arena]: https://github.com/fitzgen/generational-arena
@@ -378,6 +380,7 @@ read the [CONTRIBUTING.md] and [CODE_OF_CONDUCT.md] files first.
 [@retep998]: https://github.com/retep998
 [@SergioBenitez]: https://github.com/SergioBenitez
 [@steveklabnik]: https://github.com/steveklabnik
+[@TedDriggs]: https://github.com/TedDriggs
 [@vorner]: https://github.com/vorner
 [@withoutboats]: https://github.com/withoutboats
 [chronotope]: https://github.com/chronotope/

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -17,6 +17,7 @@ keywords    = ["abscissa", "cli", "application", "framework", "service"]
 
 [badges]
 travis-ci = { repository = "iqlusioninc/abscissa", branch = "develop" }
+maintenance = { status = "actively-developed" }
 
 [dependencies]
 failure = "0.1"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -15,6 +15,10 @@ readme      = "../README.md"
 categories  = ["command-line-interface", "rust-patterns"]
 keywords    = ["abscissa", "cli", "application", "framework", "service"]
 
+[badges]
+travis-ci = { repository = "iqlusioninc/abscissa", branch = "develop" }
+maintenance = { status = "actively-developed" }
+
 [dependencies]
 abscissa_derive = { version = "0.3.0-rc.0", path = "../derive" }
 canonical-path = "2"
@@ -47,6 +51,3 @@ signals = ["libc", "signal-hook"]
 terminal = ["termcolor"]
 testing = ["regex", "wait-timeout"]
 time = ["chrono"]
-
-[badges]
-travis-ci = { repository = "iqlusioninc/abscissa", branch = "develop" }

--- a/core/src/application.rs
+++ b/core/src/application.rs
@@ -14,11 +14,11 @@ use crate::{
     component::Component,
     config::{Config, Configurable},
     error::{FrameworkError, FrameworkErrorKind::*},
-    logging::{self, LoggingComponent},
+    logging::{self, Logging},
     path::{AbsPathBuf, ExePath, RootPath},
     runnable::Runnable,
     shutdown::Shutdown,
-    terminal::{component::TerminalComponent, ColorChoice},
+    terminal::{component::Terminal, ColorChoice},
     Version,
 };
 use std::{env, path::Path, process, vec};
@@ -117,8 +117,8 @@ pub trait Application: Default + Sized + 'static {
         &mut self,
         command: &Self::Cmd,
     ) -> Result<Vec<Box<dyn Component<Self>>>, FrameworkError> {
-        let terminal = TerminalComponent::new(self.term_colors(command));
-        let logging = LoggingComponent::new(self.logging_config(command))
+        let terminal = Terminal::new(self.term_colors(command));
+        let logging = Logging::new(self.logging_config(command))
             .expect("logging subsystem failed to initialize");
 
         Ok(vec![Box::new(terminal), Box::new(logging)])

--- a/core/src/component.rs
+++ b/core/src/component.rs
@@ -54,15 +54,18 @@ where
     /// Version of this component
     fn version(&self) -> Version;
 
-    /// Names of the components this components depends on
-    fn dependencies(&self) -> Iter<'_, Id> {
-        [].iter()
-    }
-
     /// Lifecycle event called when application configuration should be loaded
     /// if it were possible.
     fn after_config(&mut self, config: &A::Cfg) -> Result<(), FrameworkError> {
         Ok(())
+    }
+
+    /// Names of the components this component depends on.
+    ///
+    /// After this app's `after_config` callback is fired, the
+    /// `register_dependency` callback below will be fired for each of these.
+    fn dependencies(&self) -> Iter<'_, Id> {
+        [].iter()
     }
 
     /// Register a dependency of this component (a.k.a. "dependency injection")
@@ -71,7 +74,7 @@ where
         handle: Handle,
         dependency: &mut dyn Component<A>,
     ) -> Result<(), FrameworkError> {
-        Ok(())
+        unimplemented!();
     }
 
     /// Perform any tasks which should occur before the app exits

--- a/core/src/logging.rs
+++ b/core/src/logging.rs
@@ -6,5 +6,5 @@ mod config;
 mod logger;
 
 #[cfg(feature = "application")]
-pub use self::component::LoggingComponent;
+pub use self::component::Logging;
 pub use self::config::Config;

--- a/core/src/logging/component.rs
+++ b/core/src/logging/component.rs
@@ -8,11 +8,11 @@ use crate::{Component, FrameworkError};
 /// Abscissa component for initializing the logging subsystem
 #[derive(Component, Debug, Default)]
 #[component(core)]
-pub struct LoggingComponent {
+pub struct Logging {
     config: Config,
 }
 
-impl LoggingComponent {
+impl Logging {
     /// Create a new logging component
     pub fn new(config: Config) -> Result<Self, FrameworkError> {
         logger::init(&config);

--- a/core/src/terminal.rs
+++ b/core/src/terminal.rs
@@ -14,5 +14,5 @@ pub use termcolor::{Color, ColorChoice};
 /// This is useful when Abscissa internally leverages the terminal subsystem
 /// without booting a full application, such as displaying usage information.
 pub(crate) fn init() {
-    self::component::TerminalComponent::new(ColorChoice::Auto);
+    self::component::Terminal::new(ColorChoice::Auto);
 }

--- a/core/src/terminal/component.rs
+++ b/core/src/terminal/component.rs
@@ -8,18 +8,18 @@ use termcolor::ColorChoice;
 /// Abscissa terminal subsystem component
 #[derive(Component)]
 #[component(core)]
-pub struct TerminalComponent {}
+pub struct Terminal {}
 
-impl TerminalComponent {
+impl Terminal {
     /// Create a new `TerminalComponent` with the given `ColorChoice`
-    pub fn new(color_choice: ColorChoice) -> TerminalComponent {
+    pub fn new(color_choice: ColorChoice) -> Terminal {
         // TODO(tarcieri): handle terminal reinit (without panicing)
         stream::set_color_choice(color_choice);
         Self {}
     }
 }
 
-impl fmt::Debug for TerminalComponent {
+impl fmt::Debug for Terminal {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "TerminalComponent {{ stdout, stderr }}")
     }

--- a/core/tests/component.rs
+++ b/core/tests/component.rs
@@ -2,24 +2,79 @@
 
 mod example_app;
 
-use self::example_app::ExampleApp;
-use abscissa_core::{component, Component};
+use self::example_app::{ExampleApp, ExampleConfig};
+use abscissa_core::{component, Component, FrameworkError};
 
-/// ID for `FooComponent`
-const FOO_COMPONENT_ID: component::Id = component::Id::new("component::FooComponent");
+/// ID for `FoobarComponent` (example component #1)
+const FOOBAR_COMPONENT_ID: component::Id = component::Id::new("component::FoobarComponent");
 
-/// Example component
+/// ID for `BazComponent` (example component #2)
+const BAZ_COMPONENT_ID: component::Id = component::Id::new("component::BazComponent");
+
+/// ID for `QuuxComponent` (example component #3)
+const QUUX_COMPONENT_ID: component::Id = component::Id::new("component::QuuxComponent");
+
+/// Example component #1
 #[derive(Component, Debug, Default)]
-pub struct FooComponent {
+pub struct FoobarComponent {
     /// Component state
     pub state: Option<String>,
 }
 
-impl FooComponent {
+impl FoobarComponent {
     /// Set the state string to a particular value
     pub fn set_state(&mut self, state_str: &str) {
         self.state = Some(state_str.to_owned());
     }
+}
+
+/// Example component #2
+#[derive(Component, Debug, Default)]
+pub struct BazComponent {}
+
+/// Example component #3
+#[derive(Component, Debug, Default)]
+#[component(inject = "init_foobar(component::FoobarComponent)")]
+#[component(inject = "init_baz(component::BazComponent)")]
+pub struct QuuxComponent {
+    /// State of Foo at the time we were initialized?
+    pub foobar_state: Option<String>,
+
+    /// Did we get a callback that `Baz` has been initialized?
+    pub baz_initialized: bool,
+}
+
+impl QuuxComponent {
+    /// Callback run after `FoobarComponent` has been initialized
+    pub fn init_foobar(&mut self, foobar: &mut FoobarComponent) -> Result<(), FrameworkError> {
+        self.foobar_state = foobar.state.clone();
+        foobar.state = Some("hijacked!".to_owned());
+        Ok(())
+    }
+
+    /// Callback run after `BazComponent` has been initialized
+    pub fn init_baz(&mut self, _baz: &BazComponent) -> Result<(), FrameworkError> {
+        self.baz_initialized = true;
+        Ok(())
+    }
+}
+
+fn init_components() -> Vec<Box<dyn Component<ExampleApp>>> {
+    let mut foobar = FoobarComponent::default();
+    foobar.set_state("original foobar state");
+
+    let component1 = Box::new(foobar);
+    let component2 = Box::new(BazComponent::default());
+    let component3 = Box::new(QuuxComponent::default());
+
+    let components: Vec<Box<dyn Component<ExampleApp>>> = vec![component1, component2, component3];
+
+    // Ensure component IDs are as expected
+    assert_eq!(components[0].id(), FOOBAR_COMPONENT_ID);
+    assert_eq!(components[1].id(), BAZ_COMPONENT_ID);
+    assert_eq!(components[2].id(), QUUX_COMPONENT_ID);
+
+    components
 }
 
 #[test]
@@ -27,29 +82,53 @@ fn component_registration() {
     let mut registry = component::Registry::default();
     assert!(registry.is_empty());
 
-    let component = Box::new(FooComponent::default()) as Box<dyn Component<ExampleApp>>;
-    assert_eq!(component.id(), FOO_COMPONENT_ID);
+    let components = init_components();
 
-    registry.register(vec![component]).unwrap();
-    assert!(!registry.is_empty());
+    registry.register(components).unwrap();
+    assert_eq!(registry.len(), 3);
 
-    let foo = registry.get_by_id(FOO_COMPONENT_ID).unwrap();
-    assert_eq!(foo.id(), FOO_COMPONENT_ID);
+    // Fetch components and make sure they got registered correctly
+    let foobar = registry.get_by_id(FOOBAR_COMPONENT_ID).unwrap();
+    assert_eq!(foobar.id(), FOOBAR_COMPONENT_ID);
+
+    let baz = registry.get_by_id(BAZ_COMPONENT_ID).unwrap();
+    assert_eq!(baz.id(), BAZ_COMPONENT_ID);
+
+    let quux = registry.get_by_id(QUUX_COMPONENT_ID).unwrap();
+    assert_eq!(quux.id(), QUUX_COMPONENT_ID);
 }
 
 #[test]
 fn get_downcast_ref() {
     let mut registry = component::Registry::default();
-    let component = Box::new(FooComponent::default()) as Box<dyn Component<ExampleApp>>;
+    let component = Box::new(FoobarComponent::default()) as Box<dyn Component<ExampleApp>>;
     registry.register(vec![component]).unwrap();
 
     {
-        let foo_mut = registry.get_downcast_mut::<FooComponent>().unwrap();
+        let foo_mut = registry.get_downcast_mut::<FoobarComponent>().unwrap();
         foo_mut.set_state("mutated!");
     }
 
     {
-        let foo = registry.get_downcast_ref::<FooComponent>().unwrap();
+        let foo = registry.get_downcast_ref::<FoobarComponent>().unwrap();
         assert_eq!(foo.state.as_ref().unwrap(), "mutated!");
     }
+}
+
+#[test]
+fn dependency_injection() {
+    let mut registry = component::Registry::default();
+    let mut components = init_components();
+
+    // Start component up in reverse order to make sure sorting works
+    components.reverse();
+
+    registry.register(components).unwrap();
+    registry.after_config(&ExampleConfig::default()).unwrap();
+
+    let foobar = registry.get_downcast_ref::<FoobarComponent>().unwrap();
+    assert_eq!(foobar.state.as_ref().unwrap(), "hijacked!");
+
+    let quux = registry.get_downcast_ref::<QuuxComponent>().unwrap();
+    assert_eq!(quux.foobar_state.as_ref().unwrap(), "original foobar state");
 }

--- a/derive/Cargo.toml
+++ b/derive/Cargo.toml
@@ -11,11 +11,13 @@ readme      = "README.md"
 
 [badges]
 travis-ci = { repository = "iqlusioninc/abscissa", branch = "develop" }
+maintenance = { status = "actively-developed" }
 
 [lib]
 proc-macro = true
 
 [dependencies]
+darling = "0.9"
 heck = "0.3"
 proc-macro2 = "0.4"
 quote = "0.6"


### PR DESCRIPTION
Adds a custom attribute used by `derive(Component)` to derive the `Component::register_dependency` method, handling type conversions along the way.

Uses proc macros to downcast components to the requested type. For now it seems to be working out.

Tests dependency injection by reversing component order, letting the registry sort them by their dependencies and then invoke the appropriate callbacks. Tests the callbacks were actually fired.

Adds the `darling` crate as a proc macro attribute parser because it is
amazing and we should totally use it anywhere we deal with attributes.