### PR TITLE
component: Ensure registration will succeed before mutating

### DIFF
--- a/core/src/component/registry.rs
+++ b/core/src/component/registry.rs
@@ -217,20 +217,19 @@ where
         let id = component.id();
         let version = component.version();
         let type_id = (*component).type_id();
+
+        ensure!(
+            !self.id_map.contains_key(&id) && !self.type_map.contains_key(&type_id),
+            ComponentError,
+            "duplicate component registration: {}",
+            id
+        );
+
         let index = self.components.insert(component);
 
-        // Index component by ID
-        if self.id_map.insert(id, index).is_some() {
-            self.components.remove(index);
-            fail!(ComponentError, "duplicate component ID: {}", id);
-        }
-
-        // Index component by type
-        if self.type_map.insert(type_id, index).is_some() {
-            self.components.remove(index);
-            self.id_map.remove(&id);
-            fail!(ComponentError, "duplicate component type: {}", id);
-        }
+        // Index component by ID and type
+        assert!(self.id_map.insert(id, index).is_none());
+        assert!(self.type_map.insert(type_id, index).is_none());
 
         debug!("registered component: {} (v{})", id, version);
         Ok(())

--- a/core/tests/component.rs
+++ b/core/tests/component.rs
@@ -3,7 +3,7 @@
 mod example_app;
 
 use self::example_app::{ExampleApp, ExampleConfig};
-use abscissa_core::{component, Component, FrameworkError};
+use abscissa_core::{component, Component, FrameworkError, FrameworkErrorKind::ComponentError};
 
 /// ID for `FoobarComponent` (example component #1)
 const FOOBAR_COMPONENT_ID: component::Id = component::Id::new("component::FoobarComponent");
@@ -83,7 +83,6 @@ fn component_registration() {
     assert!(registry.is_empty());
 
     let components = init_components();
-
     registry.register(components).unwrap();
     assert_eq!(registry.len(), 3);
 
@@ -96,6 +95,23 @@ fn component_registration() {
 
     let quux = registry.get_by_id(QUUX_COMPONENT_ID).unwrap();
     assert_eq!(quux.id(), QUUX_COMPONENT_ID);
+}
+
+#[test]
+fn duplicate_component_registration() {
+    let foobar1 = Box::new(FoobarComponent::default());
+    let foobar2 = Box::new(FoobarComponent::default());
+    let components: Vec<Box<dyn Component<ExampleApp>>> = vec![foobar1, foobar2];
+
+    let mut registry = component::Registry::default();
+    assert!(registry.is_empty());
+
+    let err = registry.register(components).err().unwrap();
+    assert_eq!(*err.kind(), ComponentError);
+    assert_eq!(registry.len(), 1);
+
+    let foobar = registry.get_by_id(FOOBAR_COMPONENT_ID).unwrap();
+    assert_eq!(foobar.id(), FOOBAR_COMPONENT_ID);
 }
 
 #[test]


### PR DESCRIPTION
The previous implementation would encounter errors after adding components to the `Arena`, and then try to clean up changes, which accidentally deleted a key from the index in the process.

This error was captured in a test, then corrected by first ensuring that registration would succeed before performing any state mutations.

Thanks to @dirvine for pointing out something was fishy.