### PR TITLE
v0.3.0

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,16 @@
+## [0.3.0] (2019-08-05)
+
+- usage: Use bold rather than explicit color ([#126])
+- Switch from `heck` to `ident_case` ([#124])
+- component: Ensure registration will succeed before mutating ([#122])
+- component: Add #[component(dep = "...")] attribute ([#121])
+- derive: Custom derive support for `Component` ([#119])
+- component: Index Registry by TypeId ([#118])
+- component: Add `get_downcast_ref`/`get_downcast_mut` to `Registry` ([#117])
+- component: Add get_mut methods to `Registry` ([#115])
+- component: Use `generational-arena` for component storage ([#113])
+- component: allow `Registry::iter()` without mutable reference([#110])
+
 ## [0.2.1] (2019-07-27)
 
 - usage: Fix bugs when traversing subcommands ([#107])
@@ -74,6 +87,17 @@
 
 - Initial release
 
+[0.3.0]: https://github.com/iqlusioninc/abscissa/pull/127
+[#126]: https://github.com/iqlusioninc/abscissa/pull/126
+[#124]: https://github.com/iqlusioninc/abscissa/pull/124
+[#122]: https://github.com/iqlusioninc/abscissa/pull/122
+[#121]: https://github.com/iqlusioninc/abscissa/pull/121
+[#119]: https://github.com/iqlusioninc/abscissa/pull/119
+[#118]: https://github.com/iqlusioninc/abscissa/pull/118
+[#117]: https://github.com/iqlusioninc/abscissa/pull/117
+[#115]: https://github.com/iqlusioninc/abscissa/pull/115
+[#113]: https://github.com/iqlusioninc/abscissa/pull/113
+[#110]: https://github.com/iqlusioninc/abscissa/pull/110
 [0.2.1]: https://github.com/iqlusioninc/abscissa/pull/108
 [#107]: https://github.com/iqlusioninc/abscissa/pull/107
 [#106]: https://github.com/iqlusioninc/abscissa/pull/106

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2,9 +2,9 @@
 # It is not intended for manual editing.
 [[package]]
 name = "abscissa"
-version = "0.3.0-rc.0"
+version = "0.3.0"
 dependencies = [
- "abscissa_core 0.3.0-rc.0",
+ "abscissa_core 0.3.0",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "gumdrop 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "handlebars 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -15,9 +15,9 @@ dependencies = [
 
 [[package]]
 name = "abscissa_core"
-version = "0.3.0-rc.0"
+version = "0.3.0"
 dependencies = [
- "abscissa_derive 0.3.0-rc.0",
+ "abscissa_derive 0.3.0",
  "canonical-path 2.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -38,7 +38,7 @@ dependencies = [
 
 [[package]]
 name = "abscissa_derive"
-version = "0.3.0-rc.0"
+version = "0.3.0"
 dependencies = [
  "darling 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ident_case 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -5,7 +5,7 @@ description = """
               configuration, error handling, logging, and terminal interactions.
               This crate contains a CLI utility for generating new applications.
               """
-version     = "0.3.0-rc.0" # Also update html_root_url in lib.rs when bumping this
+version     = "0.3.0" # Also update html_root_url in lib.rs when bumping this
 license     = "Apache-2.0"
 authors     = ["Tony Arcieri <tony@iqlusion.io>"]
 edition     = "2018"
@@ -28,10 +28,10 @@ lazy_static = "1"
 serde = { version = "1", features = ["serde_derive"] }
 
 [dependencies.abscissa_core]
-version = "0.3.0-rc.0"
+version = "0.3"
 path = "../core"
 
 [dev-dependencies.abscissa_core]
-version = "0.3.0-rc.0"
+version = "0.3"
 features = ["testing"]
 path = "../core"

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -8,7 +8,7 @@
 #![forbid(unsafe_code)]
 #![doc(
     html_logo_url = "https://www.iqlusion.io/img/github/iqlusioninc/abscissa/abscissa-sq.svg",
-    html_root_url = "https://docs.rs/abscissa_core/0.3.0-rc.0"
+    html_root_url = "https://docs.rs/abscissa_core/0.3.0"
 )]
 
 pub mod application;

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -5,7 +5,7 @@ description = """
               configuration, error handling, logging, and terminal interactions.
               This crate contains the framework's core functionality.
               """
-version     = "0.3.0-rc.0" # Also update html_root_url in lib.rs when bumping this
+version     = "0.3.0" # Also update html_root_url in lib.rs when bumping this
 license     = "Apache-2.0"
 authors     = ["Tony Arcieri <tony@iqlusion.io>"]
 edition     = "2018"
@@ -20,7 +20,7 @@ travis-ci = { repository = "iqlusioninc/abscissa", branch = "develop" }
 maintenance = { status = "actively-developed" }
 
 [dependencies]
-abscissa_derive = { version = "0.3.0-rc.0", path = "../derive" }
+abscissa_derive = { version = "0.3", path = "../derive" }
 canonical-path = "2"
 chrono = { version = "0.4", optional = true, features = ["serde"] }
 failure = "0.1"

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -90,7 +90,7 @@
 #![forbid(unsafe_code)]
 #![doc(
     html_logo_url = "https://www.iqlusion.io/img/github/iqlusioninc/abscissa/abscissa-sq.svg",
-    html_root_url = "https://docs.rs/abscissa_core/0.3.0-rc.0"
+    html_root_url = "https://docs.rs/abscissa_core/0.3.0"
 )]
 
 /// Abscissa version

--- a/derive/Cargo.toml
+++ b/derive/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name        = "abscissa_derive"
 description = "Custom derive support for the abscissa application microframework"
-version     = "0.3.0-rc.0" # Also update html_root_url in lib.rs when bumping this
+version     = "0.3.0" # Also update html_root_url in lib.rs when bumping this
 license     = "Apache-2.0"
 authors     = ["Tony Arcieri <tony@iqlusion.io>"]
 edition     = "2018"

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -5,7 +5,7 @@
 #![forbid(unsafe_code)]
 #![doc(
     html_logo_url = "https://www.iqlusion.io/img/github/iqlusioninc/abscissa/abscissa-sq.svg",
-    html_root_url = "https://docs.rs/abscissa_derive/0.3.0-rc.0"
+    html_root_url = "https://docs.rs/abscissa_derive/0.3.0"
 )]
 
 extern crate proc_macro;


### PR DESCRIPTION
- usage: Use bold rather than explicit color (#126)
- Switch from `heck` to `ident_case` (#124)
- component: Ensure registration will succeed before mutating (#122)
- component: Add `#[component(dep = "...")]` attribute (#121)
- derive: Custom derive support for `Component` (#119)
- component: Index Registry by TypeId (#118)
- component: Add `get_downcast_ref`/`get_downcast_mut` to `Registry` (#117)
- component: Add get_mut methods to `Registry` (#115)
- component: Use `generational-arena` for component storage (#113)
- component: allow `Registry::iter()` without mutable reference(#110)