### PR TITLE
Fix issues with the signal handler thread

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -9,3 +9,4 @@ contributions under the terms of the [Apache License, Version 2.0]
 [LICENSE]: https://github.com/iqlusioninc/abscissa/blob/develop/LICENSE
 
 - Anthony Arcieri ([@tarcieri](https://github.com/tarcieri))
+- Jarrod Davis ([@jarrodldavis](https://github.com/jarrodldavis))

--- a/core/src/signal.rs
+++ b/core/src/signal.rs
@@ -99,7 +99,7 @@ where
     I: IntoIterator<Item = Signal>,
 {
     let mut app = app_lock.write();
-    let thread_name = thread::Name::new("absissa::signal");
+    let thread_name = thread::Name::new("abscissa::signal");
     let signals = Signals::new(signals.into_iter().map(|s| s.number() as c_int))
         .map_err(|e| err!(ThreadError, "{}", e))?;
 

--- a/core/src/thread/manager.rs
+++ b/core/src/thread/manager.rs
@@ -23,7 +23,7 @@ impl Manager {
         }
 
         let thread = Thread::spawn(name.clone(), f)?;
-        self.threads.insert(name.clone(), thread).unwrap();
+        self.threads.insert(name.clone(), thread);
         Ok(())
     }
 


### PR DESCRIPTION
- [x] Remove `unwrap` of `Option` returned by `HashMap::insert` -- it is expected to return `None` since a new key is inserted
- [x] Fix typo in the thread name used by the signal handler

I was also thinking of adding a helper for creating the signal handler, similiar to the existing prelude-included helpers for application state

```diff
diff --git a/cli/template/src/application.rs.hbs b/cli/template/src/application.rs.hbs
index 8c55f9a..17cfbb5 100644
--- a/cli/template/src/application.rs.hbs
+++ b/cli/template/src/application.rs.hbs
@@ -2,7 +2,7 @@
 
 use crate::{commands::{{~command_type~}}, config::{{~config_type~}}};
 use abscissa_core::{
-    application, config, logging, Application, EntryPoint, FrameworkError, StandardPaths,
+    application, config, logging, signal, Application, EntryPoint, FrameworkError, StandardPaths,
 };
 use lazy_static::lazy_static;
 
@@ -30,6 +30,24 @@ pub fn app_config() -> config::Reader<{{~application_type~}}> {
     config::Reader::new(&APPLICATION)
 }
 
+/// Register signal handlers for the given signals.
+///
+/// This requires a mutable lock on the application state.
+pub fn app_signals<I>(signals: I) -> Result<(), FrameworkError>
+where
+    I: IntoIterator<Item = signal::Signal>,
+{
+    signal::register_handler(&APPLICATION, signals)
+}
+
+/// Register signal handlers for the given signals.
+///
+/// This requires a mutable lock on the application state.
+#[macro_export]
+macro_rules! app_signals {
+    ( $( $x:expr ),+ ) => ( crate::application::app_signals(vec![ $($x,)* ]))
+}
+
 /// {{title}} Application
 #[derive(Debug)]
 pub struct {{application_type}} {
```

Obviously the idea requires more fleshing out (like including example usage in the template and better naming/documentation), but let me know if I should update this PR or create a new one.

It would be nice to have an example usage of the signal handler since I got stuck on the exclusive lock issue when testing out the handler in the template's `Start` command -- the config's read lock on the application state prevents the signal handler from working until it's dropped!

Also, perhaps it would be nice to provide `try_read` and `try_write` for `Lock<A>`:

https://github.com/iqlusioninc/abscissa/blob/350900c28086978d0304664ac8796d8e15e4c6bf/core/src/application/lock.rs#L26-L46