### PR TITLE
Improve lints and deny policy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ branches:
 env:
   global:
     - RUST_BACKTRACE=1
+    - RUSTFLAGS="-D warnings"
 
 install:
   - rustup component add rustfmt

--- a/cli/src/commands/new.rs
+++ b/cli/src/commands/new.rs
@@ -106,7 +106,7 @@ impl NewCommand {
     fn render_template_file(
         &self,
         app_template: &Collection,
-        template_file: &Template,
+        template_file: &Template<'_>,
         app_properties: &Properties,
     ) -> Result<(), Error> {
         let output_path_rel = template_file.output_path(app_properties);

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -4,12 +4,12 @@
 //!
 //! <https://docs.rs/abscissa_core>
 
-#![deny(warnings, unsafe_code, unused_qualifications)]
-#![forbid(unsafe_code)]
 #![doc(
     html_logo_url = "https://www.iqlusion.io/img/github/iqlusioninc/abscissa/abscissa-sq.svg",
     html_root_url = "https://docs.rs/abscissa_core/0.3.0"
 )]
+#![forbid(unsafe_code)]
+#![warn(rust_2018_idioms, unused_lifetimes, unused_qualifications)]
 
 pub mod application;
 pub mod commands;

--- a/cli/src/properties/name.rs
+++ b/cli/src/properties/name.rs
@@ -15,7 +15,7 @@ impl AsRef<str> for App {
 }
 
 impl fmt::Display for App {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self.0)
     }
 }

--- a/cli/src/template/collection.rs
+++ b/cli/src/template/collection.rs
@@ -71,7 +71,7 @@ impl Collection {
     }
 
     /// Iterate over the templates in the collection
-    pub fn iter(&self) -> Iter {
+    pub fn iter(&self) -> Iter<'_> {
         // TODO: better way of constructing this `Iter`
         Iter::new(
             self.0
@@ -85,7 +85,7 @@ impl Collection {
     /// Render a template
     pub fn render<W>(
         &self,
-        template: &Template,
+        template: &Template<'_>,
         properties: &Properties,
         output: W,
     ) -> Result<(), Error>

--- a/cli/src/template/name.rs
+++ b/cli/src/template/name.rs
@@ -20,7 +20,7 @@ impl AsRef<str> for Name {
 }
 
 impl fmt::Display for Name {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self.0)
     }
 }

--- a/core/src/application/name.rs
+++ b/core/src/application/name.rs
@@ -13,7 +13,7 @@ impl AsRef<str> for Name {
 }
 
 impl fmt::Display for Name {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self.0)
     }
 }

--- a/core/src/command/help.rs
+++ b/core/src/command/help.rs
@@ -42,7 +42,7 @@ impl<C> Options for Help<C>
 where
     C: Command,
 {
-    fn parse<S: AsRef<str>>(parser: &mut Parser<S>) -> Result<Self, Error> {
+    fn parse<S: AsRef<str>>(parser: &mut Parser<'_, S>) -> Result<Self, Error> {
         let mut opts = vec![];
 
         while let Some(opt) = parser.next_opt() {
@@ -58,7 +58,10 @@ where
         })
     }
 
-    fn parse_command<S: AsRef<str>>(_name: &str, parser: &mut Parser<S>) -> Result<Self, Error> {
+    fn parse_command<S: AsRef<str>>(
+        _name: &str,
+        parser: &mut Parser<'_, S>,
+    ) -> Result<Self, Error> {
         // TODO(tarcieri): is this necessary or the best approach?
         Self::parse(parser)
     }

--- a/core/src/component/id.rs
+++ b/core/src/component/id.rs
@@ -27,7 +27,7 @@ impl AsRef<str> for Id {
 }
 
 impl fmt::Display for Id {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self.0)
     }
 }

--- a/core/src/component/registry.rs
+++ b/core/src/component/registry.rs
@@ -164,12 +164,12 @@ where
     }
 
     /// Iterate over the components.
-    pub fn iter(&self) -> Iter<A> {
+    pub fn iter(&self) -> Iter<'_, A> {
         Iter::new(self.components.iter())
     }
 
     /// Iterate over the components mutably.
-    pub fn iter_mut(&mut self) -> IterMut<A> {
+    pub fn iter_mut(&mut self) -> IterMut<'_, A> {
         IterMut::new(self.components.iter_mut())
     }
 

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -86,12 +86,12 @@
 //! [RwLock]: https://doc.rust-lang.org/std/sync/struct.RwLock.html
 //! [lazy_static]: https://docs.rs/lazy_static
 
-#![deny(warnings, missing_docs, unused_import_braces, unused_qualifications)]
-#![forbid(unsafe_code)]
 #![doc(
     html_logo_url = "https://www.iqlusion.io/img/github/iqlusioninc/abscissa/abscissa-sq.svg",
     html_root_url = "https://docs.rs/abscissa_core/0.3.0"
 )]
+#![forbid(unsafe_code)]
+#![warn(rust_2018_idioms, unused_lifetimes, unused_qualifications)]
 
 /// Abscissa version
 pub const VERSION: &str = env!("CARGO_PKG_VERSION");

--- a/core/src/logging/logger.rs
+++ b/core/src/logging/logger.rs
@@ -30,7 +30,7 @@ impl Logger {
     }
 
     /// Attempt to log
-    pub fn try_log(&self, record: &Record) -> Result<(), Error> {
+    pub fn try_log(&self, record: &Record<'_>) -> Result<(), Error> {
         let mut stream = self.level_stream(record);
         let now = chrono::Utc::now();
         write!(&mut stream, "{} ", now.format("%H:%M:%S"))?;
@@ -44,7 +44,7 @@ impl Logger {
     }
 
     /// Get the stream to which a particular loglevel should be displayed
-    fn level_stream(&self, record: &Record) -> StandardStreamLock {
+    fn level_stream(&self, record: &Record<'_>) -> StandardStreamLock<'_> {
         match record.level() {
             Level::Error => &*STDERR,
             _ => &*STDOUT,
@@ -70,11 +70,11 @@ impl Logger {
 }
 
 impl Log for Logger {
-    fn enabled(&self, metadata: &Metadata) -> bool {
+    fn enabled(&self, metadata: &Metadata<'_>) -> bool {
         metadata.level() <= self.level
     }
 
-    fn log(&self, record: &Record) {
+    fn log(&self, record: &Record<'_>) {
         let result = self.try_log(record);
         debug_assert!(result.is_ok(), "logging error: {}", result.err().unwrap());
     }

--- a/core/src/signal.rs
+++ b/core/src/signal.rs
@@ -66,7 +66,7 @@ impl Signal {
 }
 
 impl fmt::Display for Signal {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self.name())
     }
 }

--- a/core/src/terminal/component.rs
+++ b/core/src/terminal/component.rs
@@ -20,7 +20,7 @@ impl Terminal {
 }
 
 impl fmt::Debug for Terminal {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "TerminalComponent {{ stdout, stderr }}")
     }
 }

--- a/core/src/testing/regex.rs
+++ b/core/src/testing/regex.rs
@@ -37,7 +37,7 @@ impl Deref for Regex {
 }
 
 impl fmt::Debug for Regex {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt::Display::fmt(&self.0, f)
     }
 }

--- a/core/src/testing/runner.rs
+++ b/core/src/testing/runner.rs
@@ -188,7 +188,7 @@ impl CmdRunner {
     }
 
     /// Run the given subcommand
-    pub fn run(&self) -> Process {
+    pub fn run(&self) -> Process<'_> {
         let guard = self
             .mutex
             .as_ref()
@@ -224,7 +224,7 @@ impl CmdRunner {
     }
 
     /// Get the exit status for the given subcommand
-    pub fn status(&self) -> ExitStatus {
+    pub fn status(&self) -> ExitStatus<'_> {
         self.run().wait().unwrap_or_else(|e| {
             panic!("error waiting for subprocess to terminate: {}", e);
         })

--- a/core/src/thread/name.rs
+++ b/core/src/thread/name.rs
@@ -18,7 +18,7 @@ impl AsRef<str> for Name {
 }
 
 impl fmt::Display for Name {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self.0)
     }
 }

--- a/derive/src/command.rs
+++ b/derive/src/command.rs
@@ -6,7 +6,7 @@ use quote::quote;
 use synstructure::Structure;
 
 /// Custom derive for `abscissa_core::command::Command`
-pub fn derive_command(s: Structure) -> TokenStream {
+pub fn derive_command(s: Structure<'_>) -> TokenStream {
     let subcommand_usage = match &s.ast().data {
         syn::Data::Enum(data) => impl_subcommand_usage_for_enum(data),
         _ => quote!(),

--- a/derive/src/component.rs
+++ b/derive/src/component.rs
@@ -6,7 +6,7 @@ use quote::quote;
 use synstructure::Structure;
 
 /// Custom derive for `abscissa_core::component::Component`
-pub fn derive_component(s: Structure) -> TokenStream {
+pub fn derive_component(s: Structure<'_>) -> TokenStream {
     let attrs = ComponentAttributes::from_derive_input(s.ast()).unwrap_or_else(|e| {
         panic!("error parsing component attributes: {}", e);
     });

--- a/derive/src/config.rs
+++ b/derive/src/config.rs
@@ -1,7 +1,7 @@
 use quote::quote;
 
 /// Custom derive for `abscissa_core::config::Config`
-pub fn derive_config(s: synstructure::Structure) -> proc_macro2::TokenStream {
+pub fn derive_config(s: synstructure::Structure<'_>) -> proc_macro2::TokenStream {
     s.gen_impl(quote! {
         gen impl Config for @Self {}
     })

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -1,14 +1,12 @@
 //! Custom derive support for the `abscissa` microframework.
 
 #![crate_type = "proc-macro"]
-#![deny(warnings, unsafe_code, unused_import_braces, unused_qualifications)]
-#![forbid(unsafe_code)]
 #![doc(
     html_logo_url = "https://www.iqlusion.io/img/github/iqlusioninc/abscissa/abscissa-sq.svg",
     html_root_url = "https://docs.rs/abscissa_derive/0.3.0"
 )]
-
-extern crate proc_macro;
+#![forbid(unsafe_code)]
+#![warn(rust_2018_idioms, unused_lifetimes, unused_qualifications)]
 
 mod command;
 mod component;

--- a/derive/src/runnable.rs
+++ b/derive/src/runnable.rs
@@ -1,7 +1,7 @@
 use quote::quote;
 
 /// Custom derive for `abscissa_core::runnable::Runnable`
-pub fn derive_runnable(s: synstructure::Structure) -> proc_macro2::TokenStream {
+pub fn derive_runnable(s: synstructure::Structure<'_>) -> proc_macro2::TokenStream {
     let body = s.each(|bi| {
         quote! { #bi.run() }
     });


### PR DESCRIPTION
- Replace `deny` on `warnings` with `-D warnings` in .travis.yml
- Change other `deny` directives to `warn` to be caught by above
- Add lints on `rust_2018_idioms` and `unused_lifetimes` to all crates
- Fix all `rust_2018_idioms`-related errors