### PR TITLE
cli/template: Lint for 2018 edition idioms; export error macros

### DIFF
--- a/cli/src/prelude.rs
+++ b/cli/src/prelude.rs
@@ -4,5 +4,8 @@
 /// Commonly used Abscissa traits
 pub use abscissa_core::{Application, Command, Runnable};
 
+/// Error macros
+pub use abscissa_core::error::macros::{};
+
 /// Logging macros
 pub use abscissa_core::log::{debug, error, info, log, log_enabled, trace, warn};

--- a/cli/template/src/lib.rs.hbs
+++ b/cli/template/src/lib.rs.hbs
@@ -4,8 +4,10 @@
 //!
 //! [Abscissa]: https://github.com/iqlusioninc/abscissa
 
-#![deny(warnings, missing_docs, trivial_casts, unused_qualifications)]
+// Tip: Deny warnings with `RUSTFLAGS="-D warnings"` environment variable in CI
+
 #![forbid(unsafe_code)]
+#![warn(rust_2018_idioms, unused_lifetimes, unused_qualifications)]
 
 pub mod application;
 pub mod commands;

--- a/cli/template/src/prelude.rs.hbs
+++ b/cli/template/src/prelude.rs.hbs
@@ -7,5 +7,8 @@ pub use crate::application::{app_config, app_reader, app_writer};
 /// Commonly used Abscissa traits
 pub use abscissa_core::{Application, Command, Runnable};
 
+/// Error macros
+pub use abscissa_core::{ensure, fail, fatal};
+
 /// Logging macros
 pub use abscissa_core::log::{debug, error, info, log, log_enabled, trace, warn};


### PR DESCRIPTION
Adds a `rust_2018_idioms` lint to the default template.

Re-exports the `abscissa_core::{ensure, fail, fatal}` macros from the generated app's prelude.