### PR TITLE
v0.4.0

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,13 @@
+## [0.4.0] (2019-10-13)
+
+- Update dependencies: `gumdrop` 0.7, `secrecy` 0.4 ([#141])
+- template: Lint for 2018 edition idioms; export error macros ([#136])
+- Improve lints and deny policy ([#135])
+- derive: Update to 1.0 versions of proc-macro2/quote/syn ([#134])
+- Support positional arguments in usage descriptions ([#131])
+- Fix issues with the signal handler thread ([#130])
+- template: Add `Deref` impl on Error newtype ([#129])
+
 ## [0.3.0] (2019-08-05)
 
 - usage: Use bold rather than explicit color ([#126])
@@ -87,6 +97,14 @@
 
 - Initial release
 
+[0.4.0]: https://github.com/iqlusioninc/abscissa/pull/142
+[#141]: https://github.com/iqlusioninc/abscissa/pull/141
+[#136]: https://github.com/iqlusioninc/abscissa/pull/136
+[#135]: https://github.com/iqlusioninc/abscissa/pull/135
+[#134]: https://github.com/iqlusioninc/abscissa/pull/134
+[#130]: https://github.com/iqlusioninc/abscissa/pull/130
+[#131]: https://github.com/iqlusioninc/abscissa/pull/131
+[#129]: https://github.com/iqlusioninc/abscissa/pull/129
 [0.3.0]: https://github.com/iqlusioninc/abscissa/pull/127
 [#126]: https://github.com/iqlusioninc/abscissa/pull/126
 [#124]: https://github.com/iqlusioninc/abscissa/pull/124

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2,9 +2,9 @@
 # It is not intended for manual editing.
 [[package]]
 name = "abscissa"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
- "abscissa_core 0.3.0",
+ "abscissa_core 0.4.0",
  "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "gumdrop 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "handlebars 2.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -15,9 +15,9 @@ dependencies = [
 
 [[package]]
 name = "abscissa_core"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
- "abscissa_derive 0.3.0",
+ "abscissa_derive 0.4.0",
  "canonical-path 2.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -38,7 +38,7 @@ dependencies = [
 
 [[package]]
 name = "abscissa_derive"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "darling 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "ident_case 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -5,7 +5,7 @@ Application microframework with support for command-line option parsing,
 configuration, error handling, logging, and terminal interactions.
 This crate contains a CLI utility for generating new applications.
 """
-version     = "0.3.0" # Also update html_root_url in lib.rs when bumping this
+version     = "0.4.0" # Also update html_root_url in lib.rs when bumping this
 license     = "Apache-2.0"
 authors     = ["Tony Arcieri <tony@iqlusion.io>"]
 edition     = "2018"
@@ -27,10 +27,10 @@ lazy_static = "1"
 serde = { version = "1", features = ["serde_derive"] }
 
 [dependencies.abscissa_core]
-version = "0.3"
+version = "0.4"
 path = "../core"
 
 [dev-dependencies.abscissa_core]
-version = "0.3"
+version = "0.4"
 features = ["testing"]
 path = "../core"

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -6,7 +6,7 @@
 
 #![doc(
     html_logo_url = "https://www.iqlusion.io/img/github/iqlusioninc/abscissa/abscissa-sq.svg",
-    html_root_url = "https://docs.rs/abscissa_core/0.3.0"
+    html_root_url = "https://docs.rs/abscissa_core/0.4.0"
 )]
 #![forbid(unsafe_code)]
 #![warn(rust_2018_idioms, unused_lifetimes, unused_qualifications)]

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -5,7 +5,7 @@ Application microframework with support for command-line option parsing,
 configuration, error handling, logging, and terminal interactions.
 This crate contains the framework's core functionality.
 """
-version     = "0.3.0" # Also update html_root_url in lib.rs when bumping this
+version     = "0.4.0" # Also update html_root_url in lib.rs when bumping this
 license     = "Apache-2.0"
 authors     = ["Tony Arcieri <tony@iqlusion.io>"]
 edition     = "2018"
@@ -19,7 +19,7 @@ keywords    = ["abscissa", "cli", "application", "framework", "service"]
 maintenance = { status = "actively-developed" }
 
 [dependencies]
-abscissa_derive = { version = "0.3", path = "../derive" }
+abscissa_derive = { version = "0.4", path = "../derive" }
 canonical-path = "2"
 chrono = { version = "0.4", optional = true, features = ["serde"] }
 failure = "0.1"

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -88,10 +88,15 @@
 
 #![doc(
     html_logo_url = "https://www.iqlusion.io/img/github/iqlusioninc/abscissa/abscissa-sq.svg",
-    html_root_url = "https://docs.rs/abscissa_core/0.3.0"
+    html_root_url = "https://docs.rs/abscissa_core/0.4.0"
 )]
 #![forbid(unsafe_code)]
-#![warn(rust_2018_idioms, unused_lifetimes, unused_qualifications)]
+#![warn(
+    missing_docs,
+    rust_2018_idioms,
+    unused_lifetimes,
+    unused_qualifications
+)]
 
 /// Abscissa version
 pub const VERSION: &str = env!("CARGO_PKG_VERSION");

--- a/derive/Cargo.toml
+++ b/derive/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name        = "abscissa_derive"
 description = "Custom derive support for the abscissa application microframework"
-version     = "0.3.0" # Also update html_root_url in lib.rs when bumping this
+version     = "0.4.0" # Also update html_root_url in lib.rs when bumping this
 license     = "Apache-2.0"
 authors     = ["Tony Arcieri <tony@iqlusion.io>"]
 edition     = "2018"

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -3,7 +3,7 @@
 #![crate_type = "proc-macro"]
 #![doc(
     html_logo_url = "https://www.iqlusion.io/img/github/iqlusioninc/abscissa/abscissa-sq.svg",
-    html_root_url = "https://docs.rs/abscissa_derive/0.3.0"
+    html_root_url = "https://docs.rs/abscissa_derive/0.4.0"
 )]
 #![forbid(unsafe_code)]
 #![warn(rust_2018_idioms, unused_lifetimes, unused_qualifications)]


### PR DESCRIPTION
- Update dependencies: `gumdrop` 0.7, `secrecy` 0.4 (#141)
- template: Lint for 2018 edition idioms; export error macros (#136)
- Improve lints and deny policy (#135)
- derive: Update to 1.0 versions of proc-macro2/quote/syn (#134)
- Support positional arguments in usage descriptions (#131)
- Fix issues with the signal handler thread (#130)
- template: Add `Deref` impl on Error newtype (#129)