### PR TITLE
template: Warn for missing docs; re-export status macros via prelude

### DIFF
--- a/cli/template/src/lib.rs.hbs
+++ b/cli/template/src/lib.rs.hbs
@@ -7,7 +7,13 @@
 // Tip: Deny warnings with `RUSTFLAGS="-D warnings"` environment variable in CI
 
 #![forbid(unsafe_code)]
-#![warn(rust_2018_idioms, unused_lifetimes, unused_qualifications)]
+#![warn(
+    missing_docs,
+    rust_2018_idioms,
+    trivial_casts,
+    unused_lifetimes,
+    unused_qualifications
+)]
 
 pub mod application;
 pub mod commands;

--- a/cli/template/src/prelude.rs.hbs
+++ b/cli/template/src/prelude.rs.hbs
@@ -12,3 +12,6 @@ pub use abscissa_core::{ensure, fail, fatal};
 
 /// Logging macros
 pub use abscissa_core::log::{debug, error, info, log, log_enabled, trace, warn};
+
+/// Status macros
+pub use abscissa_core::{status_err, status_info, status_ok, status_warn};

--- a/cli/template/tests/acceptance.rs.hbs
+++ b/cli/template/tests/acceptance.rs.hbs
@@ -7,8 +7,16 @@
 //! For more information, see:
 //! <https://docs.rs/abscissa_core/latest/abscissa_core/testing/index.html>
 
-#![deny(warnings, missing_docs, trivial_casts, unused_qualifications)]
+// Tip: Deny warnings with `RUSTFLAGS="-D warnings"` environment variable in CI
+
 #![forbid(unsafe_code)]
+#![warn(
+    missing_docs,
+    rust_2018_idioms,
+    trivial_casts,
+    unused_lifetimes,
+    unused_qualifications
+)]
 
 use abscissa_core::testing::prelude::*;
 use {{name}}::config::{{config_type}};


### PR DESCRIPTION
- Adds `missing_docs` to the list of warnings in template-generated files
- Re-export all status macros via the prelude