### PR TITLE
terminal: Add `color-backtrace` crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -20,6 +20,7 @@ dependencies = [
  "abscissa_derive 0.4.0",
  "canonical-path 2.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "color-backtrace 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "generational-arena 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "gumdrop 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -60,6 +61,15 @@ dependencies = [
 name = "arc-swap"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "atty"
+version = "0.2.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "autocfg"
@@ -140,6 +150,16 @@ dependencies = [
  "num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "color-backtrace"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "atty 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "backtrace 0.3.38 (registry+https://github.com/rust-lang/crates.io-index)",
+ "termcolor 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -645,6 +665,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [metadata]
 "checksum aho-corasick 0.7.6 (registry+https://github.com/rust-lang/crates.io-index)" = "58fb5e95d83b38284460a5fda7d6470aa0b8844d283a0b614b8535e880800d2d"
 "checksum arc-swap 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "f1a1eca3195b729bbd64e292ef2f5fff6b1c28504fed762ce2b1013dde4d8e92"
+"checksum atty 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)" = "1803c647a3ec87095e7ae7acfca019e98de5ec9a7d01343f611cf3152ed71a90"
 "checksum autocfg 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "b671c8fb71b457dd4ae18c4ba1e59aa81793daacc361d82fcd410cef0d491875"
 "checksum backtrace 0.3.38 (registry+https://github.com/rust-lang/crates.io-index)" = "690a62be8920ccf773ee00ef0968649b0e724cda8bd5b12286302b4ae955fdf5"
 "checksum backtrace-sys 0.1.31 (registry+https://github.com/rust-lang/crates.io-index)" = "82a830b4ef2d1124a711c71d263c5abdc710ef8e907bd508c88be475cebc422b"
@@ -656,6 +677,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum cc 1.0.45 (registry+https://github.com/rust-lang/crates.io-index)" = "4fc9a35e1f4290eb9e5fc54ba6cf40671ed2a2514c3eeb2b2a908dda2ea5a1be"
 "checksum cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)" = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
 "checksum chrono 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)" = "e8493056968583b0193c1bb04d6f7684586f3726992d6c573261941a895dbd68"
+"checksum color-backtrace 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "65d13f1078cc63c791d0deba0dd43db37c9ec02b311f10bed10b577016f3a957"
 "checksum darling 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3fe629a532efad5526454efb0700f86d5ad7ff001acb37e431c8bf017a432a8e"
 "checksum darling_core 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ee54512bec54b41cf2337a22ddfadb53c7d4c738494dc2a186d7b037ad683b85"
 "checksum darling_macro 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0cd3e432e52c0810b72898296a69d66b1d78d1517dff6cde7a130557a55a62c1"

--- a/README.md
+++ b/README.md
@@ -96,34 +96,36 @@ default set of features in the application:
 |----|------------------------|-----------------|----------------|-------------------------|
 | 1  | [abscissa_core]        | [iqlusion]      | Apache-2.0     | Abscissa framework      |
 | 2  | [arc-swap]             | [@vorner]       | Apache-2.0/MIT | Atomic swap for `Arc`   |
-| 3  | [autocfg]              | [@cuviper]      | Apache-2.0/MIT | Rust compiler configs   |
-| 4  | [backtrace]            | [@alexcrichton] | Apache-2.0/MIT | Capture stack traces    |
-| 5  | [backtrace-sys]        | [@alexcrichton] | Apache-2.0/MIT | Capture stack traces    |
-| 6  | [canonical-path]       | [iqlusion]      | Apache-2.0     | Get canonical fs paths  |
-| 7  | [chrono]               | [chronotope]    | Apache-2.0/MIT | Time/date library       |
-| 8  | [failure]              | [@withoutboats] | Apache-2.0/MIT | Error handling          |
-| 9  | [generational-arena]   | [@fitzgen]      | MPL-2.0        | Component allocator     |
-| 10 | [gumdrop]              | [@Murarth]      | Apache-2.0/MIT | Command-line options    |
-| 11 | [lazy_static]          | [rust-lang]     | Apache-2.0/MIT | Heap-allocated statics  |
-| 12 | [libc]                 | [rust-lang]     | Apache-2.0/MIT | C library wrapper       |
-| 13 | [log]                  | [rust-lang]     | Apache-2.0/MIT | Logging facade library  |
-| 14 | [num-integer]          | [rust-num]      | Apache-2.0/MIT | `Integer` trait         |
-| 15 | [num-traits]           | [rust-num]      | Apache-2.0/MIT | Numeric traits          |
-| 16 | [redox_syscall]        | [redox-os]      | MIT            | Redox OS syscall API    |
-| 17 | [rustc-demangle]       | [@alexcrichton] | Apache-2.0/MIT | Symbol demangling       |
-| 18 | [secrecy]              | [iqlusion]      | Apache-2.0     | Secret-keeping types    |
-| 19 | [semver]               | [@steveklabnik] | Apache-2.0/MIT | Semantic versioning     |
-| 20 | [semver-parser]        | [@steveklabnik] | Apache-2.0/MIT | Parser for semver spec  |
-| 21 | [serde]                | [serde-rs]      | Apache-2.0/MIT | Serialization framework |
-| 22 | [signal-hook]          | [@vorner]       | Apache-2.0/MIT | Unix signal handling    |
-| 23 | [signal-hook-registry] | [@vorner]       | Apache-2.0/MIT | Unix signal registry    |
-| 24 | [termcolor]            | [@BurntSushi]   | MIT/Unlicense  | Terminal color support  |
-| 25 | [time]                 | [rust-lang]     | Apache-2.0/MIT | Time/date library       |
-| 26 | [toml]                 | [@alexcrichton] | Apache-2.0/MIT | TOML parser library     |
-| 27 | [winapi]§              | [@retep998]     | Apache-2.0/MIT | Windows FFI bindings    |
-| 28 | [winapi-util]          | [@BurntSushi]   | MIT/Unlicense  | Safe winapi wrappers    |
-| 29 | [wincolor]             | [@BurntSushi]   | MIT/Unlicense  | Windows console color   |
-| 30 | [zeroize]              | [iqlusion]      | Apache-2.0/MIT | Zero out sensitive data |
+| 3  | [atty]                 | [@softprops]    | MIT            | Detect TTY presence     |
+| 4  | [autocfg]              | [@cuviper]      | Apache-2.0/MIT | Rust compiler configs   |
+| 5  | [backtrace]            | [@alexcrichton] | Apache-2.0/MIT | Capture stack traces    |
+| 6  | [backtrace-sys]        | [@alexcrichton] | Apache-2.0/MIT | Capture stack traces    |
+| 7  | [canonical-path]       | [iqlusion]      | Apache-2.0     | Get canonical fs paths  |
+| 8  | [chrono]               | [chronotope]    | Apache-2.0/MIT | Time/date library       |
+| 9  | [color-backtrace]      | [@athre0z]      | Apache-2.0/MIT | Rich colored backtraces |
+| 10 | [failure]              | [@withoutboats] | Apache-2.0/MIT | Error handling          |
+| 11 | [generational-arena]   | [@fitzgen]      | MPL-2.0        | Component allocator     |
+| 12 | [gumdrop]              | [@Murarth]      | Apache-2.0/MIT | Command-line options    |
+| 13 | [lazy_static]          | [rust-lang]     | Apache-2.0/MIT | Heap-allocated statics  |
+| 14 | [libc]                 | [rust-lang]     | Apache-2.0/MIT | C library wrapper       |
+| 15 | [log]                  | [rust-lang]     | Apache-2.0/MIT | Logging facade library  |
+| 16 | [num-integer]          | [rust-num]      | Apache-2.0/MIT | `Integer` trait         |
+| 17 | [num-traits]           | [rust-num]      | Apache-2.0/MIT | Numeric traits          |
+| 18 | [redox_syscall]        | [redox-os]      | MIT            | Redox OS syscall API    |
+| 19 | [rustc-demangle]       | [@alexcrichton] | Apache-2.0/MIT | Symbol demangling       |
+| 20 | [secrecy]              | [iqlusion]      | Apache-2.0     | Secret-keeping types    |
+| 21 | [semver]               | [@steveklabnik] | Apache-2.0/MIT | Semantic versioning     |
+| 22 | [semver-parser]        | [@steveklabnik] | Apache-2.0/MIT | Parser for semver spec  |
+| 23 | [serde]                | [serde-rs]      | Apache-2.0/MIT | Serialization framework |
+| 24 | [signal-hook]          | [@vorner]       | Apache-2.0/MIT | Unix signal handling    |
+| 25 | [signal-hook-registry] | [@vorner]       | Apache-2.0/MIT | Unix signal registry    |
+| 26 | [termcolor]            | [@BurntSushi]   | MIT/Unlicense  | Terminal color support  |
+| 27 | [time]                 | [rust-lang]     | Apache-2.0/MIT | Time/date library       |
+| 28 | [toml]                 | [@alexcrichton] | Apache-2.0/MIT | TOML parser library     |
+| 29 | [winapi]§              | [@retep998]     | Apache-2.0/MIT | Windows FFI bindings    |
+| 30 | [winapi-util]          | [@BurntSushi]   | MIT/Unlicense  | Safe winapi wrappers    |
+| 31 | [wincolor]             | [@BurntSushi]   | MIT/Unlicense  | Windows console color   |
+| 32 | [zeroize]              | [iqlusion]      | Apache-2.0/MIT | Zero out sensitive data |
 
 ### Build / Development / Testing Dependencies
 
@@ -168,13 +170,15 @@ so you only compile the parts you need.
 | [abscissa_derive]      | -                | [abscissa_core]   |
 | [aho-corasick]         | `testing`        | [regex]           |
 | [arc-swap]             | `signals`        | [signal-hook-registry] |
+| [atty]                 | `terminal`       | [color-backtrace] |
 | [autocfg]              | `time`           | [num-integer]     |
 | [backtrace]            | -                | [failure]         |
 | [backtrace-sys]        | -                | [backtrace]       |
 | [canonical-path]       | -                | [abscissa_core]   |
 | [cc]                   | -                | [backtrace-sys]   |
 | [cfg-if]               | -                | [backtrace], [log] |
-| [chrono]               | `time`           | [abscissa_core]    |
+| [color-backtrace]      | `terminal`       | [abscissa_core]   |
+| [chrono]               | `time`           | [abscissa_core]   |
 | [darling]              | -                | [abscissa_derive] |
 | [darling_core]         | -                | [darling], [darling_macro] |
 | [darling_macro]        | -                | [darling]         |
@@ -344,11 +348,13 @@ read the [CONTRIBUTING.md] and [CODE_OF_CONDUCT.md] files first.
 [abscissa_derive]: https://crates.io/crates/abscissa_derive
 [aho-corasick]: https://crates.io/crates/aho-corasick
 [arc-swap]: https://crates.io/crates/arc-swap
+[atty]: https://github.com/softprops/atty
 [autocfg]: https://crates.io/crates/autocfg
 [backtrace]: https://crates.io/crates/backtrace
 [backtrace-sys]: https://crates.io/crates/backtrace-sys
 [byteorder]: https://crates.io/crates/byteorder
 [canonical-path]: https://crates.io/crates/canonical-path
+[color-backtrace]: https://github.com/athre0z/color-backtrace
 [cc]: https://crates.io/crates/cc
 [cfg-if]: https://crates.io/crates/cfg-if
 [chrono]: https://crates.io/crates/chrono

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -22,6 +22,7 @@ maintenance = { status = "actively-developed" }
 abscissa_derive = { version = "0.4", path = "../derive" }
 canonical-path = "2"
 chrono = { version = "0.4", optional = true, features = ["serde"] }
+color-backtrace = { version = "0.3", optional = true, default-features = false }
 failure = "0.1"
 generational-arena = { version = "0.2", optional = true }
 gumdrop = { version = "0.7", optional = true }
@@ -40,13 +41,13 @@ libc = { version = "0.2", optional = true }
 signal-hook = { version = "0.1", optional = true }
 
 [features]
-default = ["application", "generational-arena", "signals", "secrets", "testing", "time"]
-application = ["config", "logging", "options", "semver/serde", "terminal"]
+default = ["application", "signals", "secrets", "testing", "time"]
+application = ["config", "generational-arena", "logging", "options", "semver/serde", "terminal"]
 config = ["secrets", "serde", "terminal", "toml"]
 logging = ["log"]
 options = ["gumdrop"]
 secrets = ["secrecy"]
 signals = ["libc", "signal-hook"]
-terminal = ["termcolor"]
+terminal = ["color-backtrace", "termcolor"]
 testing = ["regex", "wait-timeout"]
 time = ["chrono"]

--- a/core/src/terminal/component.rs
+++ b/core/src/terminal/component.rs
@@ -13,8 +13,13 @@ pub struct Terminal {}
 impl Terminal {
     /// Create a new `TerminalComponent` with the given `ColorChoice`
     pub fn new(color_choice: ColorChoice) -> Terminal {
-        // TODO(tarcieri): handle terminal reinit (without panicing)
+        // TODO(tarcieri): handle terminal reinit (without panicking)
         stream::set_color_choice(color_choice);
+
+        if color_choice != ColorChoice::Never {
+            color_backtrace::install();
+        }
+
         Self {}
     }
 }


### PR DESCRIPTION
The `color-backtrace` crate provides colorized, richly formatted backtraces when crashes occur:

https://github.com/athre0z/color-backtrace

When built with debug symbols, it's also capable of displaying the relevant source code for each stack frame in the backtrace.

With `default-features = false`, it's nicely parsimonious with our existing dependencies, and only adds a single additional transitive dependency, `atty` (which we previously used, and should potentially consider using again).

![color-backtrace screenshot](https://i.imgur.com/jLznHxp.png)