### PR TITLE
Completely replace `lazy_static` with `once_cell`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8,7 +8,7 @@ dependencies = [
  "gumdrop 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "handlebars 2.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "ident_case 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "once_cell 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.103 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -22,12 +22,14 @@ maintenance = { status = "actively-developed" }
 gumdrop = "0.7"
 handlebars = "2"
 ident_case = "1"
-lazy_static = "1"
 serde = { version = "1", features = ["serde_derive"] }
 
 [dependencies.abscissa_core]
 version = "0.4"
 path = "../core"
+
+[dev-dependencies]
+once_cell = "1.2"
 
 [dev-dependencies.abscissa_core]
 version = "0.4"

--- a/cli/src/application.rs
+++ b/cli/src/application.rs
@@ -2,14 +2,12 @@
 
 use super::{commands::CliCommand, config::CliConfig};
 use abscissa_core::{
-    self, application, trace, Application, EntryPoint, FrameworkError, StandardPaths,
+    application::{AppCell, State},
+    trace, Application, EntryPoint, FrameworkError, StandardPaths,
 };
-use lazy_static::lazy_static;
 
-lazy_static! {
-    /// Application state
-    pub static ref APPLICATION: application::Lock<CliApplication> = application::Lock::default();
-}
+/// Application state
+pub static APPLICATION: AppCell<CliApplication> = AppCell::new();
 
 /// Abscissa CLI Application
 #[derive(Debug)]
@@ -18,7 +16,7 @@ pub struct CliApplication {
     config: Option<CliConfig>,
 
     /// Application state.
-    state: application::State<Self>,
+    state: State<Self>,
 }
 
 impl Default for CliApplication {
@@ -39,11 +37,11 @@ impl Application for CliApplication {
         self.config.as_ref().expect("config not loaded")
     }
 
-    fn state(&self) -> &application::State<Self> {
+    fn state(&self) -> &State<Self> {
         &self.state
     }
 
-    fn state_mut(&mut self) -> &mut application::State<Self> {
+    fn state_mut(&mut self) -> &mut State<Self> {
         &mut self.state
     }
 

--- a/cli/template/Cargo.toml.hbs
+++ b/cli/template/Cargo.toml.hbs
@@ -6,7 +6,6 @@ edition = "{{edition}}"
 
 [dependencies]
 gumdrop = "0.7"
-lazy_static = "1"
 serde = { version = "1", features = ["serde_derive"] }
 
 [dependencies.abscissa_core]
@@ -15,9 +14,9 @@ version = "{{abscissa.version}}"
 # see https://github.com/rust-lang/backtrace-rs/issues/189
 # features = ["gimli-backtrace"]
 
-[dev-dependencies.abscissa_core]
-version = "{{abscissa.version}}"
-features = ["testing"]
+[dev-dependencies]
+abscissa_core = { version = "{{abscissa.version}}", features = ["testing"] }
+once_cell = "1.2"
 
 {{#if patch_crates_io~}}
 [patch.crates-io]

--- a/cli/template/src/application.rs.hbs
+++ b/cli/template/src/application.rs.hbs
@@ -2,14 +2,12 @@
 
 use crate::{commands::{{~command_type~}}, config::{{~config_type~}}};
 use abscissa_core::{
-    application, config, trace, Application, EntryPoint, FrameworkError, StandardPaths,
+    application::{self, AppCell},
+    config, trace, Application, EntryPoint, FrameworkError, StandardPaths,
 };
-use lazy_static::lazy_static;
 
-lazy_static! {
-    /// Application state
-    pub static ref APPLICATION: application::Lock<{{~application_type~}}> = application::Lock::default();
-}
+/// Application state
+pub static APPLICATION: AppCell<{{~application_type~}}> = AppCell::new();
 
 /// Obtain a read-only (multi-reader) lock on the application state.
 ///

--- a/cli/template/tests/acceptance.rs.hbs
+++ b/cli/template/tests/acceptance.rs.hbs
@@ -20,17 +20,15 @@
 
 use abscissa_core::testing::prelude::*;
 use {{name}}::config::{{config_type}};
-use lazy_static::lazy_static;
+use once_cell::sync::Lazy;
 
-lazy_static! {
-    /// Executes your application binary via `cargo run`.
-    ///
-    /// Storing this value in a `lazy_static!` ensures that all instances of
-    /// the runner acquire a mutex when executing commands and inspecting
-    /// exit statuses, serializing what would otherwise be multithreaded
-    /// invocations as `cargo test` executes tests in parallel by default.
-    pub static ref RUNNER: CmdRunner = CmdRunner::default();
-}
+/// Executes your application binary via `cargo run`.
+///
+/// Storing this value as a [`Lazy`] static ensures that all instances of
+/// the runner acquire a mutex when executing commands and inspecting
+/// exit statuses, serializing what would otherwise be multithreaded
+/// invocations as `cargo test` executes tests in parallel by default.
+pub static RUNNER: Lazy<CmdRunner> = Lazy::new(|| CmdRunner::default());
 
 /// Use `{{config_type}}::default()` value if no config or args
 #[test]

--- a/cli/tests/app/README.md
+++ b/cli/tests/app/README.md
@@ -1,7 +1,9 @@
 # App Tests
 
 Any `*.rs` files in the `tests/app` directory will be copied to the `tests/`
-directory of the generated application prior to `cargo test` being run.
+directory of the generated application prior to `cargo test` being run
+during Abscissa's own integration testing.
 
 This allows for programmatically testing properties and/or behavior within the
-generated application.
+generated application without making the tests part of the default application
+template.

--- a/cli/tests/app/exit_status.rs
+++ b/cli/tests/app/exit_status.rs
@@ -4,11 +4,9 @@
 #![forbid(unsafe_code)]
 
 use abscissa_core::testing::CmdRunner;
-use lazy_static::lazy_static;
+use once_cell::sync::Lazy;
 
-lazy_static! {
-    pub static ref RUNNER: CmdRunner = CmdRunner::default();
-}
+pub static RUNNER: Lazy<CmdRunner> = Lazy::new(|| CmdRunner::default());
 
 #[test]
 fn no_args() {

--- a/cli/tests/generate_app.rs
+++ b/cli/tests/generate_app.rs
@@ -5,7 +5,7 @@
 #![forbid(unsafe_code)]
 
 use abscissa_core::testing::prelude::*;
-use lazy_static::lazy_static;
+use once_cell::sync::Lazy;
 use std::{env, fs, path::Path};
 
 /// Name of our test application
@@ -19,13 +19,11 @@ const TEST_COMMANDS: &[&str] = &[
     "clippy",
 ];
 
-lazy_static! {
-    pub static ref RUNNER: CmdRunner = {
-        let mut runner = CmdRunner::new("cargo");
-        runner.exclusive();
-        runner
-    };
-}
+pub static RUNNER: Lazy<CmdRunner> = Lazy::new(|| {
+    let mut runner = CmdRunner::new("cargo");
+    runner.exclusive();
+    runner
+});
 
 /// Run tests against the generated application
 #[test]

--- a/core/src/application/cell.rs
+++ b/core/src/application/cell.rs
@@ -1,0 +1,57 @@
+//! Application Cell: holder of application state.
+
+use super::{
+    lock::{Lock, Reader, Writer},
+    Application,
+};
+use once_cell::sync::OnceCell;
+
+/// Newtype wrapper for the cell type we use.
+///
+/// This allows us to define methods on the type, which we do below on the
+/// `AppCell` alias (trait bounds on `const fn` types aren't yet stable).
+pub struct Cell<T>(OnceCell<T>);
+
+impl<T> Cell<T> {
+    /// Create a new application cell.
+    pub const fn new() -> Cell<T> {
+        Self(OnceCell::new())
+    }
+}
+
+/// Application cells.
+///
+/// These are defined as a type alias as it's not yet stable to have trait
+/// bounds on types with `const fn` yet.
+pub type AppCell<A> = Cell<Lock<A>>;
+
+impl<A: Application> AppCell<A> {
+    /// Set the application state to the given value.
+    ///
+    /// This can only be performed once without causing a crash.
+    pub(crate) fn set_once(&self, app: A) {
+        self.0.set(Lock::new(app)).unwrap_or_else(|_| {
+            panic!("Abscissa applications can't be rebooted (yet)!");
+        })
+    }
+
+    /// Get the application state, acquiring a shared, read-only lock
+    /// around it which permits concurrent access by multiple readers.
+    pub fn read(&'static self) -> Reader<A> {
+        self.0.get().unwrap_or_else(|| not_loaded()).read()
+    }
+
+    /// Obtain an exclusive lock on the application state, allowing it to be
+    /// accessed mutably.
+    pub fn write(&'static self) -> Writer<A> {
+        self.0.get().unwrap_or_else(|| not_loaded()).write()
+    }
+}
+
+/// Error handler called if `get()` is invoked before the global
+/// application state has been initialized.
+///
+/// This indicates a bug in the program accessing this type.
+fn not_loaded() -> ! {
+    panic!("Abscissa application state accessed before it has been initialized!")
+}

--- a/core/src/application/lock/reader.rs
+++ b/core/src/application/lock/reader.rs
@@ -4,7 +4,7 @@ use super::Application;
 use std::{ops::Deref, sync::RwLockReadGuard};
 
 /// Generic `RwLockWriteGuard` for a `'static` lifetime.
-pub(crate) type Guard<T> = RwLockReadGuard<'static, Option<T>>;
+pub(crate) type Guard<T> = RwLockReadGuard<'static, T>;
 
 /// Wrapper around a `RwLockReadGuard` for reading global application state.
 pub struct Reader<A>(Guard<A>)
@@ -28,14 +28,6 @@ where
     type Target = A;
 
     fn deref(&self) -> &A {
-        self.0.deref().as_ref().unwrap_or_else(|| not_loaded())
+        self.0.deref()
     }
-}
-
-/// Error handler called if `get()` is invoked before the global
-/// application state has been initialized.
-///
-/// This indicates a bug in the program accessing this type.
-fn not_loaded() -> ! {
-    panic!("Abscissa application state accessed before it has been initialized!")
 }

--- a/core/src/application/lock/writer.rs
+++ b/core/src/application/lock/writer.rs
@@ -4,7 +4,7 @@ use super::Application;
 use std::{ops, sync::RwLockWriteGuard};
 
 /// Generic `RwLockReadGuard` for a `'static` lifetime.
-pub(crate) type WriterGuard<T> = RwLockWriteGuard<'static, Option<T>>;
+pub(crate) type WriterGuard<T> = RwLockWriteGuard<'static, T>;
 
 /// Wrapper around a `RwLockReadGuard` for reading global application state.
 pub struct Writer<A>(WriterGuard<A>)
@@ -28,7 +28,7 @@ where
     type Target = A;
 
     fn deref(&self) -> &A {
-        self.0.deref().as_ref().unwrap()
+        self.0.deref()
     }
 }
 
@@ -37,6 +37,6 @@ where
     A: 'static + Application,
 {
     fn deref_mut(&mut self) -> &mut A {
-        self.0.deref_mut().as_mut().unwrap()
+        self.0.deref_mut()
     }
 }

--- a/core/src/config/reader.rs
+++ b/core/src/config/reader.rs
@@ -1,6 +1,6 @@
 //! Mutex guard for immutably accessing global application configuration
 
-use crate::application::{self, Application};
+use crate::application::{self, AppCell, Application};
 use std::ops::Deref;
 
 /// Convenience wrapper for `application::lock::Reader` for simplifying
@@ -14,8 +14,8 @@ where
     A: 'static + Application,
 {
     /// Create wrapper around a read-only application mutex guard
-    pub fn new(app_lock: &'static application::Lock<A>) -> Self {
-        Reader(app_lock.read())
+    pub fn new(app_cell: &'static AppCell<A>) -> Self {
+        Reader(app_cell.read())
     }
 }
 

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -84,7 +84,6 @@
 //!
 //! [gumdrop]: https://github.com/murarth/gumdrop
 //! [RwLock]: https://doc.rust-lang.org/std/sync/struct.RwLock.html
-//! [lazy_static]: https://docs.rs/lazy_static
 
 #![doc(
     html_logo_url = "https://www.iqlusion.io/img/github/iqlusioninc/abscissa/abscissa-sq.svg",


### PR DESCRIPTION
This eliminates all previous usages of `lazy_static`, including in the new application template, with an `AppCell` type which is based on `OnceCell`.

Unlike `lazy_static`, `OnceCell` does not require macros, and because of that can be hidden within the framework as an implementation detail.

It's also on track for potential inclusion in the standard library, which would allow us to eventually eliminate it as a dependency:

https://github.com/rust-lang/rfcs/pull/2788

Overall, the previous usage patterns for `lazy_static` were hacking around the lack of a `OnceCell`-like API, so this is a net win.