### PR TITLE
Split core prelude from template

### DIFF
--- a/cli/src/prelude.rs
+++ b/cli/src/prelude.rs
@@ -1,14 +1,5 @@
 //! Application-local prelude: conveniently import types/functions/macros
 //! which are generally useful and should be available everywhere.
 
-/// Commonly used Abscissa traits
-pub use abscissa_core::{Application, Command, Runnable};
-
-/// Error macros
-pub use abscissa_core::{ensure, fail, fatal, format_err};
-
-/// Tracing macros
-pub use abscissa_core::tracing::{debug, error, event, info, span, trace, warn, Level};
-
-/// Status macros
-pub use abscissa_core::{status_err, status_info, status_ok, status_warn};
+/// Abscissa core prelude
+pub use abscissa_core::prelude::*;

--- a/cli/template/src/prelude.rs.hbs
+++ b/cli/template/src/prelude.rs.hbs
@@ -1,17 +1,9 @@
 //! Application-local prelude: conveniently import types/functions/macros
-//! which are generally useful and should be available everywhere.
+//! which are generally useful and should be available in every module with
+//! `use crate::prelude::*;
+
+/// Abscissa core prelude
+pub use abscissa_core::prelude::*;
 
 /// Application state accessors
 pub use crate::application::{app_config, app_reader, app_writer};
-
-/// Commonly used Abscissa traits
-pub use abscissa_core::{Application, Command, Runnable};
-
-/// Error macros
-pub use abscissa_core::{ensure, fail, fatal, format_err};
-
-/// Tracing macros
-pub use abscissa_core::tracing::{debug, error, event, info, span, trace, warn, Level};
-
-/// Status macros
-pub use abscissa_core::{status_err, status_info, status_ok, status_warn};

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -124,6 +124,7 @@ pub mod component;
 #[cfg(feature = "config")]
 pub mod config;
 pub mod path;
+pub mod prelude;
 mod runnable;
 #[cfg(feature = "application")]
 mod shutdown;

--- a/core/src/prelude.rs
+++ b/core/src/prelude.rs
@@ -1,0 +1,13 @@
+//! Core prelude: imported in every application's `prelude.rs`
+
+/// Commonly used Abscissa traits
+pub use crate::{Application, Command, Runnable};
+
+/// Error macros
+pub use crate::{ensure, fail, fatal, format_err};
+
+/// Tracing macros
+pub use crate::tracing::{debug, error, event, info, span, trace, warn, Level};
+
+/// Status macros
+pub use crate::{status_err, status_info, status_ok, status_warn};


### PR DESCRIPTION
Moving parts of the prelude into the framework itself eliminates the need to update boilerplate whenever the prelude changes.