### PR TITLE
template: Wire up .gitignore

### DIFF
--- a/cli/src/template/collection.rs
+++ b/cli/src/template/collection.rs
@@ -22,6 +22,7 @@ macro_rules! template {
 /// Presently all of these need to be declared explicitly, and end in `.hbs`
 // TODO(tarcieri): use `build.rs` to automatically manage these?
 const DEFAULT_TEMPLATE_FILES: &[(&str, &str)] = &[
+    template!(".gitignore.hbs"),
     template!("Cargo.toml.hbs"),
     template!("README.md.hbs"),
     template!("src/application.rs.hbs"),


### PR DESCRIPTION
There's a Handlebars template for `.gitignore`, but it wasn't included in this (manually maintained) list. Per the TODO it'd be nice if `build.rs` built the list automatically.