### PR TITLE
cli: add `gen cmd` subcommand

### DIFF
--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -1,16 +1,20 @@
 //! Abscissa CLI Subcommands
 
-mod new;
-mod version;
+pub mod gen;
+pub mod new;
+pub mod version;
 
-use self::{new::NewCommand, version::VersionCommand};
+use self::{gen::GenCommand, new::NewCommand, version::VersionCommand};
 use super::config::CliConfig;
 use abscissa_core::{Command, Configurable, Help, Options, Runnable};
 use std::path::PathBuf;
 
 /// Abscissa CLI Subcommands
-#[derive(Runnable, Command, Debug, Options)]
+#[derive(Command, Debug, Options, Runnable)]
 pub enum CliCommand {
+    #[options(help = "generate a new module in an existing app")]
+    Gen(GenCommand),
+
     #[options(help = "show help for a command")]
     Help(Help<Self>),
 

--- a/cli/src/commands/gen.rs
+++ b/cli/src/commands/gen.rs
@@ -1,0 +1,14 @@
+//! `gen` subcommand: code generator functionality
+
+mod cmd;
+
+pub use cmd::Cmd;
+
+use abscissa_core::{Command, Options, Runnable};
+
+/// `gen` subcommand: code generator functionality
+#[derive(Command, Debug, Options, Runnable)]
+pub enum GenCommand {
+    /// Generate a new subcommand
+    Cmd(Cmd),
+}

--- a/cli/src/commands/gen/cmd.rs
+++ b/cli/src/commands/gen/cmd.rs
@@ -1,0 +1,105 @@
+//! Generate a new subcommand in an existing application
+
+use crate::{config::target_app_root, error::Error, handlebars_registry, prelude::*};
+use abscissa_core::{Command, Options, Runnable};
+use ident_case::RenameRule;
+use serde::Serialize;
+use std::{
+    fs,
+    path::{Path, PathBuf},
+    process::exit,
+};
+
+/// Subcommand template file
+const SUBCOMMAND_TEMPLATE: &str = include_str!("../../../template/src/commands/subcommand.rs.hbs");
+
+/// Generate a new subcommand in an existing application
+#[derive(Command, Debug, Options)]
+pub struct Cmd {
+    /// Path to the application's `Cargo.toml`
+    #[options(help = "path to the application's Cargo.toml")]
+    manifest_path: Option<PathBuf>,
+
+    /// Names of the commands
+    #[options(free)]
+    names: Vec<String>,
+}
+
+impl Runnable for Cmd {
+    fn run(&self) {
+        if self.names.is_empty() {
+            status_err!("no command name given!");
+            eprintln!("usage: abscissa gen cmd <commandname>");
+            exit(1);
+        }
+
+        let app_root = target_app_root(self.manifest_path.as_ref().map(AsRef::as_ref));
+
+        for name in &self.names {
+            self.generate(&app_root, name)
+        }
+    }
+}
+
+impl Cmd {
+    /// Generate a new subcommand in this application
+    pub fn generate(&self, app_root: &Path, name: &str) {
+        let snake_case_name = name.replace("-", "_");
+        let output_dir = app_root.join("src").join("commands");
+
+        if !output_dir.exists() {
+            status_err!("command directory missing: {}", output_dir.display());
+            exit(1);
+        }
+
+        let mut output_path = output_dir.join(&snake_case_name);
+        output_path.set_extension("rs");
+
+        self.render(&snake_case_name, &output_path)
+            .unwrap_or_else(|e| {
+                status_err!("error rendering template: {}", e);
+                exit(1);
+            })
+    }
+
+    /// Render the subcommand template
+    pub fn render(&self, snake_case_name: &str, output_path: &Path) -> Result<(), Error> {
+        let hbs = handlebars_registry!();
+        let output_data =
+            hbs.render_template(SUBCOMMAND_TEMPLATE, &Context::new(snake_case_name))?;
+
+        fs::write(output_path, output_data)?;
+        status_ok!("Generated", "{}", output_path.display());
+
+        // TODO(tarcieri): do this automagically
+        status_info!(
+            "Notice",
+            "add `pub mod {}` to your app's commands.rs",
+            snake_case_name
+        );
+
+        Ok(())
+    }
+}
+
+/// Rendering context for `subcommand.rs.hbs`
+#[derive(Serialize)]
+struct Context {
+    /// Name in lower case (i.e. "kebab-case")
+    name_lower: String,
+
+    /// Capitalized (i.e. "PascalCase")
+    name_capital: String,
+}
+
+impl Context {
+    /// Create a new rendering context from the snake case name
+    pub fn new(snake_case_name: &str) -> Self {
+        let name_lower = RenameRule::KebabCase.apply_to_field(snake_case_name);
+        let name_capital = RenameRule::PascalCase.apply_to_field(snake_case_name);
+        Self {
+            name_lower,
+            name_capital,
+        }
+    }
+}

--- a/cli/src/commands/new.rs
+++ b/cli/src/commands/new.rs
@@ -1,4 +1,4 @@
-//! `generate` subcommand - generate a new Abscissa application
+//! `new` subcommand - generate a new Abscissa application
 
 #![allow(clippy::never_loop)]
 

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -1,6 +1,48 @@
 //! Abscissa CLI Config
 
+use crate::prelude::*;
 use serde::{Deserialize, Serialize};
+use std::{
+    env,
+    path::{Path, PathBuf},
+    process::exit,
+};
+
+/// Locate the root of the target application (with optional manifest path)
+pub fn target_app_root(manifest_path: Option<&Path>) -> PathBuf {
+    match manifest_path {
+        Some(path) => {
+            if !path.exists() || path.parent().is_none() {
+                status_err!("the manifest-path must be a path to a Cargo.toml file");
+                exit(1);
+            }
+
+            path.parent().unwrap().to_owned()
+        }
+        None => {
+            let cwd = env::current_dir()
+                .expect("couldn't get current working directory!")
+                .canonicalize()
+                .expect("couldn't canonicalize current working directory!");
+
+            let mut path = cwd.as_path();
+
+            loop {
+                if path.join("Cargo.toml").exists() {
+                    return path.to_owned();
+                }
+
+                match path.parent() {
+                    Some(p) => path = p,
+                    None => {
+                        status_err!("couldn't find application root!");
+                        exit(1);
+                    }
+                }
+            }
+        }
+    }
+}
 
 /// Abscissa CLI Config
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]

--- a/cli/src/error.rs
+++ b/cli/src/error.rs
@@ -89,6 +89,12 @@ impl From<handlebars::RenderError> for Error {
     }
 }
 
+impl From<handlebars::TemplateRenderError> for Error {
+    fn from(err: handlebars::TemplateRenderError) -> Self {
+        ErrorKind::Template.context(err).into()
+    }
+}
+
 impl From<io::Error> for Error {
     fn from(err: io::Error) -> Self {
         ErrorKind::Io.context(err).into()

--- a/cli/src/template.rs
+++ b/cli/src/template.rs
@@ -6,6 +6,7 @@ use std::path::{Path, PathBuf};
 mod collection;
 mod iter;
 mod name;
+mod registry;
 
 pub use self::{collection::Collection, iter::Iter, name::Name};
 

--- a/cli/src/template/collection.rs
+++ b/cli/src/template/collection.rs
@@ -4,6 +4,7 @@
 use super::{iter::Iter, Template};
 use crate::{
     error::{Error, ErrorKind},
+    handlebars_registry,
     prelude::*,
     properties::Properties,
 };
@@ -60,9 +61,7 @@ impl Collection {
     where
         I: Iterator<Item = (&'a str, &'a str)>,
     {
-        let mut hbs = Handlebars::new();
-        hbs.set_strict_mode(true);
-        hbs.register_escape_fn(handlebars::no_escape);
+        let mut hbs = handlebars_registry!();
 
         for (name, contents) in template_files {
             debug!("registering template: {}", name);

--- a/cli/src/template/registry.rs
+++ b/cli/src/template/registry.rs
@@ -1,0 +1,16 @@
+//! Helper for creating a Handlebars registry
+//!
+//! This is a workaround for `handlebars::registry::Registry` not being
+//! exported as part of the public API.
+//!
+//! So, instead, we use a macro.
+
+#[macro_export]
+macro_rules! handlebars_registry {
+    () => {{
+        let mut hbs = handlebars::Handlebars::new();
+        hbs.set_strict_mode(true);
+        hbs.register_escape_fn(handlebars::no_escape);
+        hbs
+    }};
+}

--- a/cli/template/src/commands/subcommand.rs.hbs
+++ b/cli/template/src/commands/subcommand.rs.hbs
@@ -1,0 +1,32 @@
+//! `{{~name_lower~}}` subcommand
+
+use abscissa_core::{Command, Options, Runnable};
+
+/// `{{~name_lower~}}` subcommand
+///
+/// The `Options` proc macro generates an option parser based on the struct
+/// definition, and is defined in the `gumdrop` crate. See their documentation
+/// for a more comprehensive example:
+///
+/// <https://docs.rs/gumdrop/>
+#[derive(Command, Debug, Options)]
+pub struct {{name_capital}} {
+    // Example `--foobar` (with short `-f` argument)
+    // #[options(short = "f", help = "foobar path"]
+    // foobar: Option<PathBuf>
+
+    // Example `--baz` argument with no short version
+    // #[options(no_short, help = "baz path")]
+    // baz: Options<PathBuf>
+
+    // "free" arguments don't have an associated flag
+    // #[options(free)]
+    // free_args: Vec<String>,
+}
+
+impl Runnable for {{name_capital}} {
+    /// Start the application.
+    fn run(&self) {
+        // Your code goes here
+    }
+}

--- a/cli/tests/generate_app.rs
+++ b/cli/tests/generate_app.rs
@@ -29,7 +29,13 @@ pub static RUNNER: Lazy<CmdRunner> = Lazy::new(|| {
 #[test]
 fn test_generated_app() {
     let app_path = env::temp_dir().join(APP_NAME);
+
+    // Generate the application
     generate_app(&app_path);
+
+    // Generate an additional subcommand
+    generate_subcommand(&app_path);
+
     env::set_current_dir(&app_path).unwrap();
 
     for test_command in TEST_COMMANDS {
@@ -72,4 +78,23 @@ fn generate_app(path: &Path) {
         )
         .unwrap();
     }
+}
+
+/// Generate a subcommand using `abscissa gen cmd`
+fn generate_subcommand(path: &Path) {
+    let manifest_path = path.join("Cargo.toml");
+
+    // Name of the example subcommand to generate
+    let name = "foo-bar-baz";
+
+    CmdRunner::default()
+        .args(&[
+            "gen",
+            "cmd",
+            "--manifest-path",
+            &manifest_path.display().to_string(),
+            name,
+        ])
+        .status()
+        .expect_success();
 }


### PR DESCRIPTION
Insipired by `rails generate`, this adds a template-based boilerplate generator for adding subcommands to an existing application:

    $ abscissa gen cmd foo-bar

This generates a new subcommand from a `subcommand.rs.hbs` template file which includes some examples of how to use the `gumdrop` proc macro DSL for defining command line argument parsing.