### PR TITLE
v0.5.0

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,8 +4,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 0.5.0 (UNRELEASED)
+## [0.5.0] (2019-12-16)
+### Added
+- `color-backtrace` support ([#148])
+- `gimli-backtrace` Cargo feature ([#150])
+- cli: automatically generate `Cargo.lock` ([#176])
+- cli: add `gen cmd` subcommand ([#177])
+
 ### Changed
+- template: warn for missing docs; re-export status macros via prelude ([#147])
+- Upgrade `secrecy` crate to v0.6 ([#169])
+- template: Wire up `.gitignore` ([#175])
+
 #### Replaced `lazy_static` with `once_cell` ([#167], [#168])
 
 Abscissa primarily used `lazy_static` in two places:
@@ -113,6 +123,18 @@ impl Application {
 ```
 
 [`tracing`]: https://github.com/tokio-rs/tracing
+
+#### Split core prelude from template ([#172])
+
+Existing users may want to update their `prelude.rs` to look like:
+
+```rust
+/// Abscissa core prelude
+pub use abscissa_core::prelude::*;
+
+/// Application state accessors
+pub use crate::application::{app_config, app_reader, app_writer};
+```
 
 ### Removed
 #### Replaced `Config` custom derive with blanket impl ([#152])
@@ -366,11 +388,20 @@ impl std::error::Error for Error {
 
 - Initial release
 
+[0.5.0]: https://github.com/iqlusioninc/abscissa/pull/178
+[#177]: https://github.com/iqlusioninc/abscissa/pull/177
+[#176]: https://github.com/iqlusioninc/abscissa/pull/176
+[#175]: https://github.com/iqlusioninc/abscissa/pull/175
+[#172]: https://github.com/iqlusioninc/abscissa/pull/172
+[#169]: https://github.com/iqlusioninc/abscissa/pull/169
 [#168]: https://github.com/iqlusioninc/abscissa/pull/168
 [#167]: https://github.com/iqlusioninc/abscissa/pull/167
 [#154]: https://github.com/iqlusioninc/abscissa/pull/154
 [#152]: https://github.com/iqlusioninc/abscissa/pull/152
 [#151]: https://github.com/iqlusioninc/abscissa/pull/151
+[#150]: https://github.com/iqlusioninc/abscissa/issues/150
+[#148]: https://github.com/iqlusioninc/abscissa/issues/148
+[#147]: https://github.com/iqlusioninc/abscissa/issues/147
 [#144]: https://github.com/iqlusioninc/abscissa/issues/144
 [0.4.0]: https://github.com/iqlusioninc/abscissa/pull/142
 [#141]: https://github.com/iqlusioninc/abscissa/pull/141

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2,9 +2,9 @@
 # It is not intended for manual editing.
 [[package]]
 name = "abscissa"
-version = "0.5.0-rc.0"
+version = "0.5.0"
 dependencies = [
- "abscissa_core 0.5.0-rc.0",
+ "abscissa_core 0.5.0",
  "gumdrop 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "handlebars 2.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "ident_case 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -14,9 +14,9 @@ dependencies = [
 
 [[package]]
 name = "abscissa_core"
-version = "0.5.0-rc.0"
+version = "0.5.0"
 dependencies = [
- "abscissa_derive 0.5.0-rc.0",
+ "abscissa_derive 0.5.0",
  "backtrace 0.3.40 (registry+https://github.com/rust-lang/crates.io-index)",
  "canonical-path 2.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -40,7 +40,7 @@ dependencies = [
 
 [[package]]
 name = "abscissa_derive"
-version = "0.5.0-rc.0"
+version = "0.5.0"
 dependencies = [
  "darling 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "ident_case 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/README.md
+++ b/README.md
@@ -97,65 +97,79 @@ default set of features in the application:
 | #  | Crate Name             | Origin          | License        | Description             |
 |----|------------------------|-----------------|----------------|-------------------------|
 | 1  | [abscissa_core]        | [iqlusion]      | Apache-2.0     | Abscissa framework      |
-| 2  | [arc-swap]             | [@vorner]       | Apache-2.0/MIT | Atomic swap for `Arc`   |
-| 3  | [atty]                 | [@softprops]    | MIT            | Detect TTY presence     |
-| 4  | [autocfg]              | [@cuviper]      | Apache-2.0/MIT | Rust compiler configs   |
-| 5  | [backtrace]            | [@alexcrichton] | Apache-2.0/MIT | Capture stack traces    |
-| 6  | [backtrace-sys]        | [@alexcrichton] | Apache-2.0/MIT | Capture stack traces    |
-| 7  | [canonical-path]       | [iqlusion]      | Apache-2.0     | Get canonical fs paths  |
-| 8  | [chrono]               | [chronotope]    | Apache-2.0/MIT | Time/date library       |
-| 9  | [color-backtrace]      | [@athre0z]      | Apache-2.0/MIT | Rich colored backtraces |
-| 10 | [generational-arena]   | [@fitzgen]      | MPL-2.0        | Component allocator     |
-| 11 | [gumdrop]              | [@Murarth]      | Apache-2.0/MIT | Command-line options    |
-| 12 | [lazy_static]          | [rust-lang]     | Apache-2.0/MIT | Heap-allocated statics  |
-| 13 | [libc]                 | [rust-lang]     | Apache-2.0/MIT | C library wrapper       |
-| 14 | [log]                  | [rust-lang]     | Apache-2.0/MIT | Logging facade library  |
-| 15 | [num-integer]          | [rust-num]      | Apache-2.0/MIT | `Integer` trait         |
-| 16 | [num-traits]           | [rust-num]      | Apache-2.0/MIT | Numeric traits          |
-| 17 | [redox_syscall]        | [redox-os]      | MIT            | Redox OS syscall API    |
-| 18 | [rustc-demangle]       | [@alexcrichton] | Apache-2.0/MIT | Symbol demangling       |
-| 19 | [secrecy]              | [iqlusion]      | Apache-2.0     | Secret-keeping types    |
-| 20 | [semver]               | [@steveklabnik] | Apache-2.0/MIT | Semantic versioning     |
-| 21 | [semver-parser]        | [@steveklabnik] | Apache-2.0/MIT | Parser for semver spec  |
-| 22 | [serde]                | [serde-rs]      | Apache-2.0/MIT | Serialization framework |
-| 23 | [signal-hook]          | [@vorner]       | Apache-2.0/MIT | Unix signal handling    |
-| 24 | [signal-hook-registry] | [@vorner]       | Apache-2.0/MIT | Unix signal registry    |
-| 25 | [termcolor]            | [@BurntSushi]   | MIT/Unlicense  | Terminal color support  |
-| 26 | [time]                 | [rust-lang]     | Apache-2.0/MIT | Time/date library       |
-| 27 | [toml]                 | [@alexcrichton] | Apache-2.0/MIT | TOML parser library     |
-| 28 | [winapi]§              | [@retep998]     | Apache-2.0/MIT | Windows FFI bindings    |
-| 29 | [winapi-util]          | [@BurntSushi]   | MIT/Unlicense  | Safe winapi wrappers    |
-| 30 | [wincolor]             | [@BurntSushi]   | MIT/Unlicense  | Windows console color   |
-| 31 | [zeroize]              | [iqlusion]      | Apache-2.0/MIT | Zero out sensitive data |
+| 2  | [aho-corasick]         | [@BurntSushi]   | MIT/Unlicense  | Pattern-matching alg    |
+| 3  | [ansi_term]            | [@ogham]        | MIT            | Terminal color libray   |
+| 4  | [arc-swap]             | [@vorner]       | Apache-2.0/MIT | Atomic swap for `Arc`   |
+| 5  | [atty]                 | [@softprops]    | MIT            | Detect TTY presence     |
+| 6  | [autocfg]              | [@cuviper]      | Apache-2.0/MIT | Rust compiler configs   |
+| 7  | [backtrace]            | [@alexcrichton] | Apache-2.0/MIT | Capture stack traces    |
+| 8  | [backtrace-sys]        | [@alexcrichton] | Apache-2.0/MIT | Capture stack traces    |
+| 9  | [byteorder]            | [@BurntSushi]   | MIT/Unlicense  | Byte order conversions  |
+| 10 | [canonical-path]       | [iqlusion]      | Apache-2.0     | Get canonical fs paths  |
+| 11 | [chrono]               | [chronotope]    | Apache-2.0/MIT | Time/date library       |
+| 12 | [color-backtrace]      | [@athre0z]      | Apache-2.0/MIT | Rich colored backtraces |
+| 13 | [generational-arena]   | [@fitzgen]      | MPL-2.0        | Component allocator     |
+| 14 | [gumdrop]              | [@Murarth]      | Apache-2.0/MIT | Command-line options    |
+| 15 | [lazy_static]          | [rust-lang]     | Apache-2.0/MIT | Heap-allocated statics  |
+| 16 | [libc]                 | [rust-lang]     | Apache-2.0/MIT | C library wrapper       |
+| 17 | [log]                  | [rust-lang]     | Apache-2.0/MIT | Logging facade library  |
+| 18 | [matchers]             | [@hawkw]        | MIT            | Stream regex matching   |
+| 19 | [maybe-uninit]         | [@est31]        | Apache-2.0/MIT | MaybeUninit compat      |
+| 20 | [memchr]               | [@BurntSushi]   | MIT/Unlicense  | Optimized byte search   |
+| 21 | [num-integer]          | [rust-num]      | Apache-2.0/MIT | `Integer` trait         |
+| 22 | [num-traits]           | [rust-num]      | Apache-2.0/MIT | Numeric traits          |
+| 23 | [once_cell]            | [@matklad]      | Apache-2.0/MIT | Single assignment cells |
+| 24 | [owning_ref]           | [@Kimundi]      | MIT            | Owner-carrying refs     |
+| 25 | [redox_syscall]        | [redox-os]      | MIT            | Redox OS syscall API    |
+| 26 | [regex]                | [rust-lang]     | Apache-2.0/MIT | Regular expressions     |
+| 27 | [regex-automata]       | [@BurntSushi]   | MIT/Unlicense  | Low-level regex DFAs    |
+| 28 | [regex-syntax]         | [rust-lang]     | Apache-2.0/MIT | Regex syntax impl       |
+| 29 | [rustc-demangle]       | [@alexcrichton] | Apache-2.0/MIT | Symbol demangling       |
+| 30 | [secrecy]              | [iqlusion]      | Apache-2.0     | Secret-keeping types    |
+| 31 | [semver]               | [@steveklabnik] | Apache-2.0/MIT | Semantic versioning     |
+| 32 | [semver-parser]        | [@steveklabnik] | Apache-2.0/MIT | Parser for semver spec  |
+| 33 | [serde]                | [serde-rs]      | Apache-2.0/MIT | Serialization framework |
+| 34 | [signal-hook]          | [@vorner]       | Apache-2.0/MIT | Unix signal handling    |
+| 35 | [signal-hook-registry] | [@vorner]       | Apache-2.0/MIT | Unix signal registry    |
+| 36 | [smallvec]             | [servo]         | Apache-2.0/MIT | Optimized small vectors |
+| 37 | [spin]                 | [@mvdnes]       | MIT            | Spinlock for no_std     |
+| 38 | [stable_deref_trait]   | [@Storyyeller]  | Apache-2.0/MIT | Stable addr marker      |
+| 39 | [termcolor]            | [@BurntSushi]   | MIT/Unlicense  | Terminal color support  |
+| 40 | [thread_local]         | [@Amanieu]      | Apache-2.0/MIT | Per-object thread local |
+| 41 | [time]                 | [rust-lang]     | Apache-2.0/MIT | Time/date library       |
+| 42 | [toml]                 | [@alexcrichton] | Apache-2.0/MIT | TOML parser library     |
+| 43 | [tracing]              | [tokio-rs]      | MIT            | App tracing / logging   |
+| 44 | [tracing-core]         | [tokio-rs]      | MIT            | App tracing / logging   |
+| 45 | [tracing-log]          | [tokio-rs]      | MIT            | `log` compatibility     |
+| 46 | [tracing-subscriber]   | [tokio-rs]      | MIT            | Tracing subscribers     |
+| 47 | [utf8-ranges]          | [@BurntSushi]   | MIT/Unlicense  | UTF-8 codepoint ranges  |
+| 48 | [winapi]§              | [@retep998]     | Apache-2.0/MIT | Windows FFI bindings    |
+| 49 | [winapi-util]          | [@BurntSushi]   | MIT/Unlicense  | Safe winapi wrappers    |
+| 50 | [wincolor]             | [@BurntSushi]   | MIT/Unlicense  | Windows console color   |
+| 51 | [zeroize]              | [iqlusion]      | Apache-2.0/MIT | Zero out sensitive data |
 
 ### Build / Development / Testing Dependencies
 
-| #  | Crate Name        | Origin           | License        | Description             |
-|----|-------------------|------------------|----------------|-------------------------|
-| 1  | [abscissa_derive] | [iqlusion]       | Apache-2.0     | Abscissa custom derive  |
-| 2  | [aho-corasick]    | [@BurntSushi]    | MIT/Unlicense  | Pattern-matching alg    |
-| 3  | [cc]              | [@alexcrichton]  | Apache-2.0/MIT | C/C++ compiler wrapper  |
-| 4  | [cfg-if]          | [@alexcrichton]  | Apache-2.0/MIT | If-like `#[cfg]` macros |
-| 5  | [darling]         | [@TedDriggs]     | MIT            | Nifty attribute parser  |
-| 6  | [darling_core]    | [@TedDriggs]     | MIT            | Attribute parser core   |
-| 7  | [darling_macro]   | [@TedDriggs]     | MIT            | Attribute parser macros |
-| 8  | [fnv]             | [@alexcrichton]  | Apache-2.0/MIT | Fast hash function      |
-| 9  | [gumdrop_derive]  | [@Murarth]       | Apache-2.0/MIT | Command-line options    |
-| 10 | [ident_case]      | [@TedDriggs]     | Apache-2.0/MIT | Case conversion utils   |
-| 11 | [memchr]          | [@BurntSushi]    | MIT/Unlicense  | Optimized byte search   |
-| 12 | [proc-macro2]     | [@alexcrichton]  | Apache-2.0/MIT | Shim for Macros 2.0 API |
-| 13 | [quote]           | [@dtolnay]       | Apache-2.0/MIT | Rust AST to token macro |
-| 14 | [regex]           | [rust-lang]      | Apache-2.0/MIT | Regular expressions     |
-| 15 | [regex-syntax]    | [rust-lang]      | Apache-2.0/MIT | Regex syntax impl       |
-| 16 | [serde_derive]    | [serde-rs]       | Apache-2.0/MIT | `serde` custom derive   |
-| 17 | [strsim]          | [@dguo]          | MIT            | String similarity utils |
-| 18 | [syn]             | [@dtolnay]       | Apache-2.0/MIT | Rust source code parser |
-| 19 | [synstructure]    | [@mystor]        | Apache-2.0/MIT | `syn` structure macros  |
-| 20 | [thread_local]    | [@Amanieu]       | Apache-2.0/MIT | Per-object thread local |
-| 21 | [ucd-util]        | [@BurntSushi]    | Apache-2.0/MIT | Unicode utilities       |
-| 22 | [unicode-xid]     | [unicode-rs]     | Apache-2.0/MIT | Identify valid Unicode  |
-| 23 | [utf8-ranges]     | [@BurntSushi]    | MIT/Unlicense  | UTF-8 codepoint ranges  |
-| 24 | [wait-timeout]    | [@alexcrichton]  | Apache-2.0/MIT | Timeouts for waitpid    |
+| #  | Crate Name           | Origin           | License        | Description             |
+|----|----------------------|------------------|----------------|-------------------------|
+| 1  | [abscissa_derive]    | [iqlusion]       | Apache-2.0     | Abscissa custom derive  |
+| 2  | [cc]                 | [@alexcrichton]  | Apache-2.0/MIT | C/C++ compiler wrapper  |
+| 3  | [cfg-if]             | [@alexcrichton]  | Apache-2.0/MIT | If-like `#[cfg]` macros |
+| 4  | [darling]            | [@TedDriggs]     | MIT            | Nifty attribute parser  |
+| 5  | [darling_core]       | [@TedDriggs]     | MIT            | Attribute parser core   |
+| 6  | [darling_macro]      | [@TedDriggs]     | MIT            | Attribute parser macros |
+| 7  | [fnv]                | [@alexcrichton]  | Apache-2.0/MIT | Fast hash function      |
+| 8  | [gumdrop_derive]     | [@Murarth]       | Apache-2.0/MIT | Command-line options    |
+| 9  | [ident_case]         | [@TedDriggs]     | Apache-2.0/MIT | Case conversion utils   |
+| 10 | [proc-macro2]        | [@alexcrichton]  | Apache-2.0/MIT | Shim for Macros 2.0 API |
+| 11 | [quote]              | [@dtolnay]       | Apache-2.0/MIT | Rust AST to token macro |
+| 12 | [serde_derive]       | [serde-rs]       | Apache-2.0/MIT | `serde` custom derive   |
+| 13 | [strsim]             | [@dguo]          | MIT            | String similarity utils |
+| 14 | [syn]                | [@dtolnay]       | Apache-2.0/MIT | Rust source code parser |
+| 15 | [synstructure]       | [@mystor]        | Apache-2.0/MIT | `syn` structure macros  |
+| 16 | [tracing-attributes] | [tokio-rs]       | MIT            | App tracing / logging   |
+| 17 | [unicode-xid]        | [unicode-rs]     | Apache-2.0/MIT | Identify valid Unicode  |
+| 18 | [wait-timeout]       | [@alexcrichton]  | Apache-2.0/MIT | Timeouts for waitpid    |
 
 ### Dependency Relationships
 
@@ -164,59 +178,75 @@ an Abscissa dependency and whether or not it is optional. Abscissa uses
 [cargo features] to allow parts of it you aren't using to be easily disabled,
 so you only compile the parts you need.
 
-| Crate Name             | [Cargo Features] | Required By       |
-|------------------------|------------------|-------------------|
-| [abscissa_core]        | -                | ⊤                 |
-| [abscissa_derive]      | -                | [abscissa_core]   |
-| [aho-corasick]         | `testing`        | [regex]           |
-| [arc-swap]             | `signals`        | [signal-hook-registry] |
-| [atty]                 | `terminal`       | [color-backtrace] |
-| [autocfg]              | `time`           | [num-integer]     |
-| [backtrace]            | -                | [abscissa_core]   |
-| [backtrace-sys]        | -                | [backtrace]       |
-| [canonical-path]       | -                | [abscissa_core]   |
-| [cc]                   | -                | [backtrace-sys]   |
-| [cfg-if]               | -                | [backtrace], [log] |
-| [color-backtrace]      | `terminal`       | [abscissa_core]   |
-| [chrono]               | `time`           | [abscissa_core]   |
-| [darling]              | -                | [abscissa_derive] |
-| [darling_core]         | -                | [darling], [darling_macro] |
-| [darling_macro]        | -                | [darling]         |
-| [fnv]                  | -                | [darling_core]    |
-| [generational-arena]   | `application`    | [abscissa_core]   |
-| [gumdrop]              | `options`        | [abscissa_core]   |
-| [gumdrop_derive]       | `options`        | [gumdrop]         |
-| [ident_case]           | -                | [abscissa_derive], [darling_core] |
-| [lazy_static]          | -                | [abscissa_core]   |
-| [libc]                 | `signals`        | [abscissa_core]   |
-| [log]                  | `logging`        | [abscissa_core]   |
-| [memchr]               | `testing`        | [aho-corasick]    |
-| [num-integer]          | `time`           | [chrono]          |
-| [num-traits]           | `time`           | [chrono], [num-integer] |
-| [proc-macro2]          | -                | [abscissa_derive], [darling], [quote], [serde_derive], [syn] |
-| [quote]                | -                | [abscissa_derive], [darling], [gumdrop_derive], [serde_derive] |
-| [redox_syscall]        | `time`           | [time]            |
-| [regex]                | `testing`        | [abscissa_core]   |
-| [rustc-demangle]       | -                | [backtrace]       |
-| [secrecy]              | `secrets`        | [abscissa_core]   |
-| [semver]               | `application`    | [abscissa_core]   |
-| [semver-parser]        | `application`    | [abscissa_core]   |
-| [serde]                | `config`         | [abscissa_core]   |
-| [serde_derive]         | `config`         | [serde]           |
-| [signal-hook]          | `signals`        | [abscissa_core]   |
-| [signal-hook-registry] | `signals`        | [signal-hook]     |
-| [strsim]               | -                | [darling_core]    |
-| [syn]                  | -                | [abscissa_derive], [darling], [gumdrop_derive], [serde_derive] |
-| [termcolor]            | `terminal`       | [abscissa_core]   |
-| [thread_local]         | `testing`        | [regex]           |
-| [time]                 | `logging`        | [chrono]          |
-| [ucd-util]             | `testing`        | [regex-syntax]    |
-| [unicode-xid]          | -                | [proc-macro2], [syn] |
-| [utf8-ranges]          | `testing`        | [regex]           |
-| [wait-timeout]         | `testing`        | [abscissa_core]   |
-| [winapi]§              | -                | [termcolor], [time], [winapi-util] |
-| [winapi-util]          | -                | [termcolor]       |
-| [zeroize]              | -                | [abscissa_core]   |
+| Crate Name             | [Cargo Features]   | Required By               |
+|------------------------|--------------------|---------------------------|
+| [abscissa_core]        | -                  | ⊤                         |
+| [abscissa_derive]      | -                  | [abscissa_core]           |
+| [aho-corasick]         | `trace`, `testing` | [regex]                   |
+| [ansi_term]            | `trace`            | [tracing-subscriber]      |
+| [arc-swap]             | `signals`          | [signal-hook-registry]    |
+| [atty]                 | `terminal`         | [color-backtrace]         |
+| [autocfg]              | `time`             | [num-integer]             |
+| [backtrace]            | -                  | [abscissa_core]           |
+| [backtrace-sys]        | -                  | [backtrace]               |
+| [byteorder]            | `trace`            | [regex-automata]          |
+| [canonical-path]       | -                  | [abscissa_core]           |
+| [cc]                   | -                  | [backtrace-sys]           |
+| [cfg-if]               | -                  | [backtrace], [log]        |
+| [color-backtrace]      | `terminal`         | [abscissa_core]           |
+| [chrono]               | `time`             | [abscissa_core]           |
+| [darling]              | -                  | [abscissa_derive]         |
+| [darling_core]         | -                  | [darling], [darling_macro] |
+| [darling_macro]        | -                  | [darling]                 |
+| [fnv]                  | -                  | [darling_core]            |
+| [generational-arena]   | `application`      | [abscissa_core]           |
+| [gumdrop]              | `options`          | [abscissa_core]           |
+| [gumdrop_derive]       | `options`          | [gumdrop]                 |
+| [ident_case]           | -                  | [abscissa_derive], [darling_core] |
+| [lazy_static]          | `testing`, `trace` | [thread_local], [tracing-core], [tracing-log], [tracing-subscriber] |
+| [libc]                 | `signals`          | [abscissa_core]           |
+| [log]                  | `logging`          | [abscissa_core]           |
+| [matchers]             | `trace`            | [tracing-subscriber]      |
+| [memchr]               | `trace`, `testing` | [aho-corasick]            |
+| [maybe-uninit]         | `trace`            | [smallvec]                |
+| [num-integer]          | `time`             | [chrono]                  |
+| [num-traits]           | `time`             | [chrono], [num-integer]   |
+| [once_cell]            | -                  | [abscissa_core]           |
+| [owning_ref]           | `trace`            | [tracing-subscriber]      |
+| [proc-macro2]          | -                  | [abscissa_derive], [darling], [quote], [serde_derive], [syn] |
+| [quote]                | -                  | [abscissa_derive], [darling], [gumdrop_derive], [serde_derive] |
+| [redox_syscall]        | `time`             | [time]                    |
+| [regex]                | `trace`, `testing` | [abscissa_core]           |
+| [regex-automata]       | `trace`            | [matchers]                |
+| [regex-syntax]         | `trace`, `testing` | [abscissa_core]           |
+| [rustc-demangle]       | -                  | [backtrace]               |
+| [secrecy]              | `secrets`          | [abscissa_core]           |
+| [semver]               | `application`      | [abscissa_core]           |
+| [semver-parser]        | `application`      | [abscissa_core]           |
+| [serde]                | `config`           | [abscissa_core]           |
+| [serde_derive]         | `config`           | [serde]                   |
+| [signal-hook]          | `signals`          | [abscissa_core]           |
+| [signal-hook-registry] | `signals`          | [signal-hook]             |
+| [smallvec]             | `trace`            | [tracing-subscriber]      |
+| [strsim]               | -                  | [darling_core]            |
+| [spin]                 | `testing`, `trace` | [lazy_static], [tracing], [tracing-core] |
+| [stable_deref_trait]   | `trace`            | [owning_ref]              |
+| [syn]                  | -                  | [abscissa_derive], [darling], [gumdrop_derive], [serde_derive] |
+| [termcolor]            | `terminal`         | [abscissa_core]           |
+| [thread_local]         | `trace`, `testing` | [regex]                   |
+| [time]                 | `logging`          | [chrono]                  |
+| [tracing]              | `trace`            | [abscissa_core]           |
+| [tracing-attributes]   | `trace`            | [tracing]                 |
+| [tracing-core]         | `trace`            | [tracing]                 |
+| [tracing-log]          | `trace`            | [abscissa_core]           |
+| [tracing-subscriber]   | `trace`            | [abscissa_core]           |
+| [unicode-xid]          | -                  | [proc-macro2], [syn]      |
+| [utf8-ranges]          | `trace`, `testing` | [regex]                   |
+| [wait-timeout]         | `testing`          | [abscissa_core]           |
+| [winapi]§              | -                  | [termcolor], [time], [winapi-util] |
+| [winapi-util]          | -                  | [termcolor]               |
+| [wincolor]             | `terminal`         | [termcolor]               |
+| [zeroize]              | -                  | [abscissa_core]           |
 
 * § `winapi` is a facade for either [winapi-i686-pc-windows-gnu] or
     [winapi-x86_64-pc-windows-gnu] which aren't explicitly listed for brevity
@@ -348,8 +378,9 @@ read the [CONTRIBUTING.md] and [CODE_OF_CONDUCT.md] files first.
 [abscissa_core]: https://crates.io/crates/abscissa_core
 [abscissa_derive]: https://crates.io/crates/abscissa_derive
 [aho-corasick]: https://crates.io/crates/aho-corasick
+[ansi_term]: https://crates.io/crates/ansi-term
 [arc-swap]: https://crates.io/crates/arc-swap
-[atty]: https://github.com/softprops/atty
+[atty]: https://crates.io/crates/atty
 [autocfg]: https://crates.io/crates/autocfg
 [backtrace]: https://crates.io/crates/backtrace
 [backtrace-sys]: https://crates.io/crates/backtrace-sys
@@ -370,13 +401,18 @@ read the [CONTRIBUTING.md] and [CODE_OF_CONDUCT.md] files first.
 [lazy_static]: https://crates.io/crates/lazy_static
 [libc]: https://crates.io/crates/libc
 [log]: https://crates.io/crates/log
+[matchers]: https://crates.io/crates/matchers
+[maybe-uninit]: https://crates.io/crates/maybe-uninit
 [memchr]: https://crates.io/crates/memchr
 [num-integer]: https://crates.io/crates/num-integer
 [num-traits]: https://crates.io/crates/num-traits
+[once_cell]: https://crates.io/crates/once_cell
+[owning_ref]: https://crates.io/crates/owning_ref
 [proc-macro2]: https://crates.io/crates/proc-macro2
 [quote]: https://crates.io/crates/quote
 [redox_syscall]: https://crates.io/crates/redox_syscall
 [regex]: https://crates.io/crates/regex
+[regex-automata]: https://crates.io/crates/regex-automata
 [regex-syntax]: https://crates.io/crates/regex-syntax
 [rustc-demangle]: https://crates.io/crates/rustc_demangle
 [secrecy]: https://crates.io/crates/secrecy
@@ -386,6 +422,9 @@ read the [CONTRIBUTING.md] and [CODE_OF_CONDUCT.md] files first.
 [serde_derive]: https://crates.io/crates/serde_derive
 [signal-hook]: https://crates.io/crates/signal-hook
 [signal-hook-registry]: https://crates.io/crates/signal-hook
+[smallvec]: https://crates.io/crates/smallvec
+[spin]: https://crates.io/crates/spin
+[stable_deref_trait]: https://crates.io/crates/stable_deref_trait
 [strsim]: https://crates.io/crates/strsim
 [syn]: https://crates.io/crates/syn
 [synstructure]: https://crates.io/crates/synstructure
@@ -393,7 +432,11 @@ read the [CONTRIBUTING.md] and [CODE_OF_CONDUCT.md] files first.
 [thread_local]: https://crates.io/crates/thread_local
 [time]: https://crates.io/crates/time
 [toml]: https://crates.io/crates/toml
-[ucd-util]: https://crates.io/crates/ucd-util
+[tracing]: https://crates.io/crates/tracing
+[tracing-attributes]: https://crates.io/crates/tracing-attributes
+[tracing-core]: https://crates.io/crates/tracing-core
+[tracing-log]: https://crates.io/crates/tracing-log
+[tracing-subscriber]: https://crates.io/crates/tracing-subscriber
 [unicode-xid]: https://crates.io/crates/unicode-xid
 [utf8-ranges]: https://crates.io/crates/utf8-ranges
 [wait-timeout]: https://crates.io/crates/wait-timeout
@@ -408,16 +451,25 @@ read the [CONTRIBUTING.md] and [CODE_OF_CONDUCT.md] files first.
 
 [@alexcrichton]: https://github.com/alexcrichton
 [@Amanieu]: https://github.com/Amanieu
+[@athre0z]: https://github.com/athre0z
 [@BurntSushi]: https://github.com/BurntSushi
 [@cuviper]: https://github.com/cuviper
 [@dguo]: https://github.com/dguo
 [@dtolnay]: https://github.com/dtolnay
+[@est31]: https://github.com/est31
 [@fitzgen]: https://github.com/fitzgen
+[@hawkw]: https://github.com/hawkw
+[@Kimundi]: https://github.com/Kimundi
+[@matklad]: https://github.com/matklad
 [@Murarth]: https://github.com/Murarth
+[@mvdnes]: https://github.com/mvdnes
 [@mystor]: https://github.com/mystor
+[@ogham]: https://github.com/ogham
 [@retep998]: https://github.com/retep998
 [@SergioBenitez]: https://github.com/SergioBenitez
 [@steveklabnik]: https://github.com/steveklabnik
+[@Storyyeller]: https://github.com/storyyeller
+[@softprops]: https://github.com/softprops
 [@TedDriggs]: https://github.com/TedDriggs
 [@vorner]: https://github.com/vorner
 [@withoutboats]: https://github.com/withoutboats
@@ -427,5 +479,7 @@ read the [CONTRIBUTING.md] and [CODE_OF_CONDUCT.md] files first.
 [rust-lang]: https://github.com/rust-lang/
 [rust-num]: https://github.com/rust-num/
 [serde-rs]: https://github.com/serde-rs/
+[servo]: https://github.com/servo
+[tokio-rs]: https://github.com/tokio-rs
 [unicode-rs]: https://github.com/unicode-rs/
 

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -5,7 +5,7 @@ Application microframework with support for command-line option parsing,
 configuration, error handling, logging, and terminal interactions.
 This crate contains a CLI utility for generating new applications.
 """
-version     = "0.5.0-rc.0" # Also update html_root_url in lib.rs when bumping this
+version     = "0.5.0" # Also update html_root_url in lib.rs when bumping this
 license     = "Apache-2.0"
 authors     = ["Tony Arcieri <tony@iqlusion.io>"]
 edition     = "2018"
@@ -25,13 +25,13 @@ ident_case = "1"
 serde = { version = "1", features = ["serde_derive"] }
 
 [dependencies.abscissa_core]
-version = "0.5.0-rc.0"
+version = "0.5"
 path = "../core"
 
 [dev-dependencies]
 once_cell = "1.2"
 
 [dev-dependencies.abscissa_core]
-version = "0.5.0-rc.0"
+version = "0.5"
 features = ["testing"]
 path = "../core"

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -6,7 +6,7 @@
 
 #![doc(
     html_logo_url = "https://www.iqlusion.io/img/github/iqlusioninc/abscissa/abscissa-sq.svg",
-    html_root_url = "https://docs.rs/abscissa_core/0.4.0"
+    html_root_url = "https://docs.rs/abscissa_core/0.5.0"
 )]
 #![forbid(unsafe_code)]
 #![warn(rust_2018_idioms, unused_lifetimes, unused_qualifications)]

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -5,7 +5,7 @@ Application microframework with support for command-line option parsing,
 configuration, error handling, logging, and terminal interactions.
 This crate contains the framework's core functionality.
 """
-version     = "0.5.0-rc.0" # Also update html_root_url in lib.rs when bumping this
+version     = "0.5.0" # Also update html_root_url in lib.rs when bumping this
 license     = "Apache-2.0"
 authors     = ["Tony Arcieri <tony@iqlusion.io>"]
 edition     = "2018"
@@ -19,7 +19,7 @@ keywords    = ["abscissa", "cli", "application", "framework", "service"]
 maintenance = { status = "actively-developed" }
 
 [dependencies]
-abscissa_derive = { version = "0.5.0-rc.0", path = "../derive" }
+abscissa_derive = { version = "0.5", path = "../derive" }
 backtrace = "0.3"
 canonical-path = "2"
 chrono = { version = "0.4", optional = true, features = ["serde"] }

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -87,7 +87,7 @@
 
 #![doc(
     html_logo_url = "https://www.iqlusion.io/img/github/iqlusioninc/abscissa/abscissa-sq.svg",
-    html_root_url = "https://docs.rs/abscissa_core/0.4.0"
+    html_root_url = "https://docs.rs/abscissa_core/0.5.0"
 )]
 #![forbid(unsafe_code)]
 #![warn(

--- a/derive/Cargo.toml
+++ b/derive/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name        = "abscissa_derive"
 description = "Custom derive support for the abscissa application microframework"
-version     = "0.5.0-rc.0" # Also update html_root_url in lib.rs when bumping this
+version     = "0.5.0" # Also update html_root_url in lib.rs when bumping this
 license     = "Apache-2.0"
 authors     = ["Tony Arcieri <tony@iqlusion.io>"]
 edition     = "2018"

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -3,7 +3,7 @@
 #![crate_type = "proc-macro"]
 #![doc(
     html_logo_url = "https://www.iqlusion.io/img/github/iqlusioninc/abscissa/abscissa-sq.svg",
-    html_root_url = "https://docs.rs/abscissa_derive/0.4.0"
+    html_root_url = "https://docs.rs/abscissa_derive/0.5.0"
 )]
 #![forbid(unsafe_code)]
 #![warn(rust_2018_idioms, unused_lifetimes, unused_qualifications)]


### PR DESCRIPTION
### Added
- `color-backtrace` support ([#148])
- `gimli-backtrace` Cargo feature ([#150])
- cli: automatically generate `Cargo.lock` ([#176])
- cli: add `gen cmd` subcommand ([#177])

### Changed
- template: warn for missing docs; re-export status macros via prelude ([#147])
- Upgrade `secrecy` crate to v0.6 ([#169])
- template: Wire up `.gitignore` ([#175])

#### Replaced `lazy_static` with `once_cell` ([#167], [#168])

Abscissa primarily used `lazy_static` in two places:

- To define the `APPLICATION` constant in `application.rs`
- To provide a shared `RUNNER` object for invoking CLI tests in
  `tests/acceptance.rs`

Both usages have now been replaced with [`once_cell`], which is a better fit for Abscissa's internal usages, and seems to stand a reasonable chance of being incorporated into the Rust standard library:

https://github.com/rust-lang/rfcs/pull/2788

Existing applications will need to replace the `lazy_static!` directive in `application.rs`:

```rust
lazy_static! {
    /// Application state
    pub static ref APPLICATION: application::Lock<MyApplication> = application::Lock::default();
}
```

with one based on the new [`AppCell`] type:

```rust
use abscissa_core::application::AppCell;

/// Application state
pub static APPLICATION: AppCell<MyApplication> = AppCell::new();
```

This change should otherwise be largely a drop-in replacement, and also means you can remove `lazy_static` from `[dependencies]` in `Cargo.toml`.

For replacing `RUNNER` in `tests/acceptance.rs`, we suggest you edit `Cargo.toml`, adding the following:

```toml
[dev-dependencies]
once_cell = "1.2"
```

And then changing the following in `tests/acceptance.rs`:

```rust
lazy_static! {
    pub static ref RUNNER: CmdRunner = CmdRunner::default();
}
```

to:

```rust
use once_cell::sync::Lazy;

pub static RUNNER: Lazy<CmdRunner> = Lazy::new(|| CmdRunner::default());
```

[`once_cell`]: https://docs.rs/once_cell
[`AppCell`]: https://docs.rs/abscissa_core/latest/abscissa_core/application/cell/type.AppCell.html

#### Replaced `log` with `tracing` ([#154])

[`tracing`] is a newer, more powerful application-level tracing library which also subsumes the functionality of a logging framework, and replaces Abscissa's previous `logging` component.

Existing apps will need to update their `application.rs`. Change the following at the bottom of the trait impl:

```rust
impl Application {
    // ...

    /// Get logging configuration from command-line options
    fn logging_config(&self, command: &MyCommand) -> logging::Config {
        if command.verbose() {
            logging::Config::verbose()
        } else {
            logging::Config::default()
        }
    }
}
```

to:

```rust
use abscissa_core::trace;

impl Application {
    // ...

    /// Get tracing configuration from command-line options
    fn tracing_config(&self, command: &EntryPoint<MyCommand>) -> trace::Config {
        if command.verbose {
            trace::Config::verbose()
        } else {
            trace::Config::default()
        }
    }
}
```

[`tracing`]: https://github.com/tokio-rs/tracing

#### Split core prelude from template ([#172])

Existing users may want to update their `prelude.rs` to look like:

```rust
/// Abscissa core prelude
pub use abscissa_core::prelude::*;

/// Application state accessors
pub use crate::application::{app_config, app_reader, app_writer};
```

### Removed
#### Replaced `Config` custom derive with blanket impl ([#152])

The previous custom derive for `Config` was replaced with a blanket impl instead. This only requires that you remove the `derive` for `Config` in existing applications' `config.rs`. Change:

```rust
use abscissa_core::{Config, EntryPoint};

/// MyApp Configuration
#[derive(Clone, Config, Debug, Deserialize, Serialize)]
#[serde(deny_unknown_fields)]
pub struct MyConfig { 
    // ...
}
```

to:

```rust
/// MyApp Configuration
#[derive(Clone, Debug, Deserialize, Serialize)]
#[serde(deny_unknown_fields)]
pub struct MyConfig { 
    // ...
}
```

(i.e. remove `Config` from the `#[derive(...)]` section)

#### Removed `failure` ([#151])

Since the time `failure` was written, `std::error::Error` has gained many of the features it was originally useful for. Many libraries now rely on it for bounds, especially in conjunction with `Box` for type erasure.

There is no prescribed replacement for `failure` at a framework-level (yet, see [#144] for some discussion).

The new `abscissa_core::error::Context` type subsumes the functionality of both the previous `abscissa_core::error::Error` type and its previous usages of `failure::Context`, e.g. capturing error sources and backtraces.

All existing usages of `abscissa_core::error::Error` will need to be updated, per the instructions below.

Existing apps are advised to do the following:

- `Cargo.toml`: remove `failure`
- `error.rs`: remove `failure` imports and `Fail` derive. `thiserror` or `err-derive` are the suggested custom derive replacements. The `Error` type definition should be changed from:
  
```rust
/// Error type
#[derive(Debug)]
pub struct Error(abscissa_core::Error<ErrorKind>);
```

to:

```rust
use abscissa_core::error::Context;

/// Error type
#[derive(Debug)]
pub struct Error(Box<Context<ErrorKind>>);
```

- `error.rs`: add `impl ErrorKind` with `context` method: this is used for capturing an error source when using your own application's `ErrorKind` type, ala similar functionality in `failure`. Add the following impl to `ErrorKind`, allowing you to capture an error context for any error type which meets the trait bounds specified by the [`BoxError`] type:

```rust
use abscissa_core::error::BoxError;

impl ErrorKind {
    /// Create an error context from this error
    pub fn context(self, source: impl Into<BoxError>) -> Context<ErrorKind> {
        Context::new(self, Some(source.into()))
    }
}
```

- `error.rs`: replace `ErrorKind` impl of `From` with one for `Context`. After using the above `context` method, it's useful be able to convert it `into()` your application's wrapper type, particularly when writing `From` coercions from foreign error types.
  
Change:
 
```rust 
impl From<abscissa_core::Error<ErrorKind>> for Error {
    fn from(other: abscissa_core::Error<ErrorKind>) -> Self {
        Error(other)
    }
}
```

to:

```rust
use abscissa_core::error::Context;

impl From<Context<ErrorKind>> for Error {
    fn from(context: Context<ErrorKind>) -> Self {
        Error(Box::new(context))
    }
}
```

- `error.rs`: update `Error` impl of `Deref`:

```rust
impl Deref for Error {
    type Target = abscissa_core::Error<ErrorKind>;

    fn deref(&self) -> &abscissa_core::Error<ErrorKind> {
        &self.0
    }
}
```

to:

```rust
impl Deref for Error {
    type Target = Context<ErrorKind>;

    fn deref(&self) -> &Context<ErrorKind> {
        &self.0
    }
}
```

- `error.rs`: add a `std::error::Error` impl for the app `Error` type:

```rust
impl std::error::Error for Error {
    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
        self.0.source()
    }
}
```

[`BoxError`]: https://docs.rs/abscissa_core/latest/abscissa_core/error/type.BoxError.html

[#177]: https://github.com/iqlusioninc/abscissa/pull/177
[#176]: https://github.com/iqlusioninc/abscissa/pull/176
[#175]: https://github.com/iqlusioninc/abscissa/pull/175
[#172]: https://github.com/iqlusioninc/abscissa/pull/172
[#169]: https://github.com/iqlusioninc/abscissa/pull/169
[#168]: https://github.com/iqlusioninc/abscissa/pull/168
[#167]: https://github.com/iqlusioninc/abscissa/pull/167
[#154]: https://github.com/iqlusioninc/abscissa/pull/154
[#152]: https://github.com/iqlusioninc/abscissa/pull/152
[#151]: https://github.com/iqlusioninc/abscissa/pull/151
[#150]: https://github.com/iqlusioninc/abscissa/issues/150
[#148]: https://github.com/iqlusioninc/abscissa/issues/148
[#147]: https://github.com/iqlusioninc/abscissa/issues/147
[#144]: https://github.com/iqlusioninc/abscissa/issues/144