### PR TITLE
Add `thiserror` to default application boilerplate (closes #144)

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,9 +167,10 @@ default set of features in the application:
 | 13 | [strsim]             | [@dguo]          | MIT            | String similarity utils |
 | 14 | [syn]                | [@dtolnay]       | Apache-2.0/MIT | Rust source code parser |
 | 15 | [synstructure]       | [@mystor]        | Apache-2.0/MIT | `syn` structure macros  |
-| 16 | [tracing-attributes] | [tokio-rs]       | MIT            | App tracing / logging   |
-| 17 | [unicode-xid]        | [unicode-rs]     | Apache-2.0/MIT | Identify valid Unicode  |
-| 18 | [wait-timeout]       | [@alexcrichton]  | Apache-2.0/MIT | Timeouts for waitpid    |
+| 16 | [thiserror]          | [@dtolnay]       | Apache-2.0/MIT | `Error` custom derive   |
+| 17 | [tracing-attributes] | [tokio-rs]       | MIT            | App tracing / logging   |
+| 18 | [unicode-xid]        | [unicode-rs]     | Apache-2.0/MIT | Identify valid Unicode  |
+| 19 | [wait-timeout]       | [@alexcrichton]  | Apache-2.0/MIT | Timeouts for waitpid    |
 
 ### Dependency Relationships
 
@@ -233,6 +234,7 @@ so you only compile the parts you need.
 | [stable_deref_trait]   | `trace`            | [owning_ref]              |
 | [syn]                  | -                  | [abscissa_derive], [darling], [gumdrop_derive], [serde_derive] |
 | [termcolor]            | `terminal`         | [abscissa_core]           |
+| [thiserror]            | -                  | Abscissa boilerplate      |
 | [thread_local]         | `trace`, `testing` | [regex]                   |
 | [time]                 | `logging`          | [chrono]                  |
 | [tracing]              | `trace`            | [abscissa_core]           |
@@ -429,6 +431,7 @@ read the [CONTRIBUTING.md] and [CODE_OF_CONDUCT.md] files first.
 [syn]: https://crates.io/crates/syn
 [synstructure]: https://crates.io/crates/synstructure
 [termcolor]: https://crates.io/crates/termcolor
+[thiserror]: https://github.com/dtolnay/thiserror
 [thread_local]: https://crates.io/crates/thread_local
 [time]: https://crates.io/crates/time
 [toml]: https://crates.io/crates/toml

--- a/cli/template/Cargo.toml.hbs
+++ b/cli/template/Cargo.toml.hbs
@@ -7,6 +7,7 @@ edition = "{{edition}}"
 [dependencies]
 gumdrop = "0.7"
 serde = { version = "1", features = ["serde_derive"] }
+thiserror = "1"
 
 [dependencies.abscissa_core]
 version = "{{abscissa.version}}"

--- a/cli/template/src/error.rs.hbs
+++ b/cli/template/src/error.rs.hbs
@@ -6,14 +6,17 @@ use std::{
     io,
     ops::Deref,
 };
+use thiserror::Error;
 
 /// Kinds of errors
-#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[derive(Copy, Clone, Debug, Eq, Error, PartialEq)]
 pub enum ErrorKind {
     /// Error in configuration file
+    #[error("config error")]
     Config,
 
     /// Input/output error
+    #[error("I/O error")]
     Io,
 }
 
@@ -23,19 +26,6 @@ impl ErrorKind {
         Context::new(self, Some(source.into()))
     }
 }
-
-impl Display for ErrorKind {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let description = match self {
-            ErrorKind::Config => "config error",
-            ErrorKind::Io => "I/O error",
-        };
-
-        f.write_str(description)
-    }
-}
-
-impl std::error::Error for ErrorKind {}
 
 /// Error type
 #[derive(Debug)]


### PR DESCRIPTION
Provides handy custom derive support for `Error`:

https://github.com/dtolnay/thiserror

It's only provided in the default boilerplate and can be switched out easily.

This should hopefully otherwise close any open questions about error-handling.