### PR TITLE
v0.5.1

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -1,6 +1,6 @@
 # Authors
 
-All code in the Abscissa repository is Copyright © 2018-2019 iqlusion, except
+All code in the Abscissa repository is Copyright © 2018-2020 iqlusion, except
 for contributions of individual authors below, who have agreed to license their
 contributions under the terms of the [Apache License, Version 2.0]
 (included in this repository in the toplevel [LICENSE] file).

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.1] (2020-01-12)
+### Added
+- Add `thiserror` to default application boilerplate ([#188])
+
+### Fixed
+- Workaround for `#[option(command)]` usage parsing ([#187])
+
 ## [0.5.0] (2019-12-16)
 ### Added
 - `color-backtrace` support ([#148])
@@ -388,6 +395,9 @@ impl std::error::Error for Error {
 
 - Initial release
 
+[0.5.1]: https://github.com/iqlusioninc/abscissa/pull/189
+[#188]: https://github.com/iqlusioninc/abscissa/pull/188
+[#187]: https://github.com/iqlusioninc/abscissa/pull/187
 [0.5.0]: https://github.com/iqlusioninc/abscissa/pull/178
 [#177]: https://github.com/iqlusioninc/abscissa/pull/177
 [#176]: https://github.com/iqlusioninc/abscissa/pull/176

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2,9 +2,9 @@
 # It is not intended for manual editing.
 [[package]]
 name = "abscissa"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
- "abscissa_core 0.5.0",
+ "abscissa_core 0.5.1",
  "gumdrop 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "handlebars 2.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "ident_case 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -14,7 +14,7 @@ dependencies = [
 
 [[package]]
 name = "abscissa_core"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "abscissa_derive 0.5.0",
  "backtrace 0.3.40 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/README.md
+++ b/README.md
@@ -318,7 +318,7 @@ For more information, please see [CODE_OF_CONDUCT.md].
 The **abscissa** crate is distributed under the terms of the
 Apache License (Version 2.0).
 
-Copyright © 2018-2019 iqlusion
+Copyright © 2018-2020 iqlusion
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -5,7 +5,7 @@ Application microframework with support for command-line option parsing,
 configuration, error handling, logging, and terminal interactions.
 This crate contains a CLI utility for generating new applications.
 """
-version     = "0.5.0" # Also update html_root_url in lib.rs when bumping this
+version     = "0.5.1" # Also update html_root_url in lib.rs when bumping this
 license     = "Apache-2.0"
 authors     = ["Tony Arcieri <tony@iqlusion.io>"]
 edition     = "2018"

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -6,7 +6,7 @@
 
 #![doc(
     html_logo_url = "https://www.iqlusion.io/img/github/iqlusioninc/abscissa/abscissa-sq.svg",
-    html_root_url = "https://docs.rs/abscissa_core/0.5.0"
+    html_root_url = "https://docs.rs/abscissa_core/0.5.1"
 )]
 #![forbid(unsafe_code)]
 #![warn(rust_2018_idioms, unused_lifetimes, unused_qualifications)]

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -5,7 +5,7 @@ Application microframework with support for command-line option parsing,
 configuration, error handling, logging, and terminal interactions.
 This crate contains the framework's core functionality.
 """
-version     = "0.5.0" # Also update html_root_url in lib.rs when bumping this
+version     = "0.5.1" # Also update html_root_url in lib.rs when bumping this
 license     = "Apache-2.0"
 authors     = ["Tony Arcieri <tony@iqlusion.io>"]
 edition     = "2018"

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -87,7 +87,7 @@
 
 #![doc(
     html_logo_url = "https://www.iqlusion.io/img/github/iqlusioninc/abscissa/abscissa-sq.svg",
-    html_root_url = "https://docs.rs/abscissa_core/0.5.0"
+    html_root_url = "https://docs.rs/abscissa_core/0.5.1"
 )]
 #![forbid(unsafe_code)]
 #![warn(

--- a/derive/README.md
+++ b/derive/README.md
@@ -19,7 +19,7 @@ from Abscissa, and the proc macros will be in scope.
 The **abscissa_derive** crate is distributed under the terms of the
 Apache License (Version 2.0).
 
-Copyright © 2018-2019 iqlusion
+Copyright © 2018-2020 iqlusion
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.


### PR DESCRIPTION
### Added
- Add `thiserror` to default application boilerplate (#188)

### Fixed
- Workaround for `#[option(command)]` usage parsing (#187)