### PR TITLE
update `tracing-subscriber` to 0.2.0

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -53,7 +53,7 @@ jobs:
           - macos-latest
           - windows-latest
         toolchain:
-          - 1.36.0
+          - 1.39.0
           - stable
     runs-on: ${{ matrix.platform }}
     steps:

--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -10,3 +10,4 @@ contributions under the terms of the [Apache License, Version 2.0]
 
 - Anthony Arcieri ([@tarcieri](https://github.com/tarcieri))
 - Jarrod Davis ([@jarrodldavis](https://github.com/jarrodldavis))
+- Eliza Weisman ([@hawkw](https://github.com/hawkw))

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -34,7 +34,7 @@ dependencies = [
  "toml 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "tracing 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "tracing-log 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "tracing-subscriber 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tracing-subscriber 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "wait-timeout 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -380,11 +380,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "maybe-uninit"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
 name = "memchr"
 version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -424,14 +419,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "opaque-debug"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "owning_ref"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "stable_deref_trait 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
-]
 
 [[package]]
 name = "pest"
@@ -628,6 +615,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "signal-hook"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -643,14 +638,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "arc-swap 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "smallvec"
-version = "0.6.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "maybe-uninit 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -762,16 +749,15 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.1.6"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "chrono 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "matchers 0.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "owning_ref 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "smallvec 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sharded-slab 0.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "smallvec 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tracing-core 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "tracing-log 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -889,14 +875,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)" = "14b6052be84e6b71ab17edffc2eeabf5c2c3ae1fdb464aae35ac50c67a44e1f7"
 "checksum maplit 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
 "checksum matchers 0.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f099785f7595cc4b4553a174ce30dd7589ef93391ff414dbb67f62392b9e0ce1"
-"checksum maybe-uninit 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "60302e4db3a61da70c0cb7991976248362f30319e88850c487b9b95bbf059e00"
 "checksum memchr 2.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "88579771288728879b57485cc7d6b07d648c9f0141eb955f8ab7f9d45394468e"
 "checksum memmap 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "6585fd95e7bb50d6cc31e20d4cf9afb4e2ba16c5846fc76793f11218da9c475b"
 "checksum num-integer 0.1.41 (registry+https://github.com/rust-lang/crates.io-index)" = "b85e541ef8255f6cf42bbfe4ef361305c6c135d10919ecc26126c4e5ae94bc09"
 "checksum num-traits 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)" = "d4c81ffc11c212fa327657cb19dd85eb7419e163b5b076bede2bdb5c974c07e4"
 "checksum once_cell 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b1c601810575c99596d4afc46f78a678c80105117c379eb3650cf99b8a21ce5b"
 "checksum opaque-debug 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2839e79665f131bdb5782e51f2c6c9599c133c6098982a54c794358bf432529c"
-"checksum owning_ref 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "49a4b8ea2179e6a2e27411d3bca09ca6dd630821cf6894c6c7c8467a8ee7ef13"
 "checksum pest 2.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7e4fb201c5c22a55d8b24fef95f78be52738e5e1361129be1b5e862ecdb6894a"
 "checksum pest_derive 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "833d1ae558dc601e9a60366421196a8d94bc0ac980476d0b67e1d0988d72b2d0"
 "checksum pest_generator 2.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7b9fcf299b5712d06ee128a556c94709aaa04512c4dffb8ead07c5c998447fc0"
@@ -921,9 +905,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum serde_derive 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)" = "128f9e303a5a29922045a830221b8f78ec74a5f544944f3d5984f8ec3895ef64"
 "checksum serde_json 1.0.44 (registry+https://github.com/rust-lang/crates.io-index)" = "48c575e0cc52bdd09b47f330f646cf59afc586e9c4e3ccd6fc1f625b8ea1dad7"
 "checksum sha-1 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "23962131a91661d643c98940b20fcaffe62d776a823247be80a48fcb8b6fce68"
+"checksum sharded-slab 0.0.8 (registry+https://github.com/rust-lang/crates.io-index)" = "ae75d0445b5d3778c9da3d1f840faa16d0627c8607f78a74daf69e5b988c39a1"
 "checksum signal-hook 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)" = "10b9f3a1686a29f53cfd91ee5e3db3c12313ec02d33765f02c1a9645a1811e2c"
 "checksum signal-hook-registry 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "94f478ede9f64724c5d173d7bb56099ec3e2d9fc2774aac65d34b8b890405f41"
-"checksum smallvec 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)" = "f7b0758c52e15a8b5e3691eae6cc559f08eee9406e548a4477ba4e67770a82b6"
 "checksum smallvec 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "44e59e0c9fa00817912ae6e4e6e3c4fe04455e75699d06eedc7d85917ed8e8f4"
 "checksum stable_deref_trait 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "dba1a27d3efae4351c8051072d619e3ade2820635c3958d826bfea39d59b54c8"
 "checksum strsim 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)" = "032c03039aae92b350aad2e3779c352e104d919cb192ba2fabbd7b831ce4f0f6"
@@ -937,7 +921,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum tracing-attributes 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "04cfd395def5a60236e187e1ff905cb55668a59f29928dec05e6e1b1fd2ac1f3"
 "checksum tracing-core 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "13a46f11e372b8bd4b4398ea54353412fdd7fd42a8370c7e543e218cf7661978"
 "checksum tracing-log 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "5e0f8c7178e13481ff6765bd169b33e8d554c5d2bbede5e32c356194be02b9b9"
-"checksum tracing-subscriber 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "192ca16595cdd0661ce319e8eede9c975f227cdaabc4faaefdc256f43d852e45"
+"checksum tracing-subscriber 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "25dc36e47794112347ccb9ae8a05b5ec4fab45f01545e4929323cdb1a543a8f4"
 "checksum typenum 1.11.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6d2783fe2d6b8c1101136184eb41be8b1ad379e4657050b8aaff0c79ee7575f9"
 "checksum ucd-trie 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "8f00ed7be0c1ff1e24f46c3d2af4859f7e863672ba3a6e92e7cff702bf9f06c2"
 "checksum unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "826e7639553986605ec5979c7dd957c7895e93eabed50ab2ffa7f6128a75097c"

--- a/README.md
+++ b/README.md
@@ -94,59 +94,57 @@ dependencies without due consideration.
 Here are all of Abscissa's transitive dependencies when configured with the
 default set of features in the application:
 
-| #  | Crate Name             | Origin          | License        | Description             |
-|----|------------------------|-----------------|----------------|-------------------------|
-| 1  | [abscissa_core]        | [iqlusion]      | Apache-2.0     | Abscissa framework      |
-| 2  | [aho-corasick]         | [@BurntSushi]   | MIT/Unlicense  | Pattern-matching alg    |
-| 3  | [ansi_term]            | [@ogham]        | MIT            | Terminal color libray   |
-| 4  | [arc-swap]             | [@vorner]       | Apache-2.0/MIT | Atomic swap for `Arc`   |
-| 5  | [atty]                 | [@softprops]    | MIT            | Detect TTY presence     |
-| 6  | [autocfg]              | [@cuviper]      | Apache-2.0/MIT | Rust compiler configs   |
-| 7  | [backtrace]            | [@alexcrichton] | Apache-2.0/MIT | Capture stack traces    |
-| 8  | [backtrace-sys]        | [@alexcrichton] | Apache-2.0/MIT | Capture stack traces    |
-| 9  | [byteorder]            | [@BurntSushi]   | MIT/Unlicense  | Byte order conversions  |
-| 10 | [canonical-path]       | [iqlusion]      | Apache-2.0     | Get canonical fs paths  |
-| 11 | [chrono]               | [chronotope]    | Apache-2.0/MIT | Time/date library       |
-| 12 | [color-backtrace]      | [@athre0z]      | Apache-2.0/MIT | Rich colored backtraces |
-| 13 | [generational-arena]   | [@fitzgen]      | MPL-2.0        | Component allocator     |
-| 14 | [gumdrop]              | [@Murarth]      | Apache-2.0/MIT | Command-line options    |
-| 15 | [lazy_static]          | [rust-lang]     | Apache-2.0/MIT | Heap-allocated statics  |
-| 16 | [libc]                 | [rust-lang]     | Apache-2.0/MIT | C library wrapper       |
-| 17 | [log]                  | [rust-lang]     | Apache-2.0/MIT | Logging facade library  |
-| 18 | [matchers]             | [@hawkw]        | MIT            | Stream regex matching   |
-| 19 | [maybe-uninit]         | [@est31]        | Apache-2.0/MIT | MaybeUninit compat      |
-| 20 | [memchr]               | [@BurntSushi]   | MIT/Unlicense  | Optimized byte search   |
-| 21 | [num-integer]          | [rust-num]      | Apache-2.0/MIT | `Integer` trait         |
-| 22 | [num-traits]           | [rust-num]      | Apache-2.0/MIT | Numeric traits          |
-| 23 | [once_cell]            | [@matklad]      | Apache-2.0/MIT | Single assignment cells |
-| 24 | [owning_ref]           | [@Kimundi]      | MIT            | Owner-carrying refs     |
-| 25 | [redox_syscall]        | [redox-os]      | MIT            | Redox OS syscall API    |
-| 26 | [regex]                | [rust-lang]     | Apache-2.0/MIT | Regular expressions     |
-| 27 | [regex-automata]       | [@BurntSushi]   | MIT/Unlicense  | Low-level regex DFAs    |
-| 28 | [regex-syntax]         | [rust-lang]     | Apache-2.0/MIT | Regex syntax impl       |
-| 29 | [rustc-demangle]       | [@alexcrichton] | Apache-2.0/MIT | Symbol demangling       |
-| 30 | [secrecy]              | [iqlusion]      | Apache-2.0     | Secret-keeping types    |
-| 31 | [semver]               | [@steveklabnik] | Apache-2.0/MIT | Semantic versioning     |
-| 32 | [semver-parser]        | [@steveklabnik] | Apache-2.0/MIT | Parser for semver spec  |
-| 33 | [serde]                | [serde-rs]      | Apache-2.0/MIT | Serialization framework |
-| 34 | [signal-hook]          | [@vorner]       | Apache-2.0/MIT | Unix signal handling    |
-| 35 | [signal-hook-registry] | [@vorner]       | Apache-2.0/MIT | Unix signal registry    |
-| 36 | [smallvec]             | [servo]         | Apache-2.0/MIT | Optimized small vectors |
-| 37 | [spin]                 | [@mvdnes]       | MIT            | Spinlock for no_std     |
-| 38 | [stable_deref_trait]   | [@Storyyeller]  | Apache-2.0/MIT | Stable addr marker      |
-| 39 | [termcolor]            | [@BurntSushi]   | MIT/Unlicense  | Terminal color support  |
-| 40 | [thread_local]         | [@Amanieu]      | Apache-2.0/MIT | Per-object thread local |
-| 41 | [time]                 | [rust-lang]     | Apache-2.0/MIT | Time/date library       |
-| 42 | [toml]                 | [@alexcrichton] | Apache-2.0/MIT | TOML parser library     |
-| 43 | [tracing]              | [tokio-rs]      | MIT            | App tracing / logging   |
-| 44 | [tracing-core]         | [tokio-rs]      | MIT            | App tracing / logging   |
-| 45 | [tracing-log]          | [tokio-rs]      | MIT            | `log` compatibility     |
-| 46 | [tracing-subscriber]   | [tokio-rs]      | MIT            | Tracing subscribers     |
-| 47 | [utf8-ranges]          | [@BurntSushi]   | MIT/Unlicense  | UTF-8 codepoint ranges  |
-| 48 | [winapi]§              | [@retep998]     | Apache-2.0/MIT | Windows FFI bindings    |
-| 49 | [winapi-util]          | [@BurntSushi]   | MIT/Unlicense  | Safe winapi wrappers    |
-| 50 | [wincolor]             | [@BurntSushi]   | MIT/Unlicense  | Windows console color   |
-| 51 | [zeroize]              | [iqlusion]      | Apache-2.0/MIT | Zero out sensitive data |
+| #  | Crate Name             | Origin          | License        | Description               |
+|----|------------------------|-----------------|----------------|---------------------------|
+| 1  | [abscissa_core]        | [iqlusion]      | Apache-2.0     | Abscissa framework        |
+| 2  | [aho-corasick]         | [@BurntSushi]   | MIT/Unlicense  | Pattern-matching alg      |
+| 3  | [ansi_term]            | [@ogham]        | MIT            | Terminal color libray     |
+| 4  | [arc-swap]             | [@vorner]       | Apache-2.0/MIT | Atomic swap for `Arc`     |
+| 5  | [atty]                 | [@softprops]    | MIT            | Detect TTY presence       |
+| 6  | [autocfg]              | [@cuviper]      | Apache-2.0/MIT | Rust compiler configs     |
+| 7  | [backtrace]            | [@alexcrichton] | Apache-2.0/MIT | Capture stack traces      |
+| 8  | [backtrace-sys]        | [@alexcrichton] | Apache-2.0/MIT | Capture stack traces      |
+| 9  | [byteorder]            | [@BurntSushi]   | MIT/Unlicense  | Byte order conversions    |
+| 10 | [canonical-path]       | [iqlusion]      | Apache-2.0     | Get canonical fs paths    |
+| 11 | [chrono]               | [chronotope]    | Apache-2.0/MIT | Time/date library         |
+| 12 | [color-backtrace]      | [@athre0z]      | Apache-2.0/MIT | Rich colored backtraces   |
+| 13 | [generational-arena]   | [@fitzgen]      | MPL-2.0        | Component allocator       |
+| 14 | [gumdrop]              | [@Murarth]      | Apache-2.0/MIT | Command-line options      |
+| 15 | [lazy_static]          | [rust-lang]     | Apache-2.0/MIT | Heap-allocated statics    |
+| 16 | [libc]                 | [rust-lang]     | Apache-2.0/MIT | C library wrapper         |
+| 17 | [log]                  | [rust-lang]     | Apache-2.0/MIT | Logging facade library    |
+| 18 | [matchers]             | [@hawkw]        | MIT            | Stream regex matching     |
+| 19 | [maybe-uninit]         | [@est31]        | Apache-2.0/MIT | MaybeUninit compat        |
+| 20 | [memchr]               | [@BurntSushi]   | MIT/Unlicense  | Optimized byte search     |
+| 21 | [num-integer]          | [rust-num]      | Apache-2.0/MIT | `Integer` trait           |
+| 22 | [num-traits]           | [rust-num]      | Apache-2.0/MIT | Numeric traits            |
+| 23 | [once_cell]            | [@matklad]      | Apache-2.0/MIT | Single assignment cells   |
+| 24 | [redox_syscall]        | [redox-os]      | MIT            | Redox OS syscall API      |
+| 25 | [regex]                | [rust-lang]     | Apache-2.0/MIT | Regular expressions       |
+| 26 | [regex-automata]       | [@BurntSushi]   | MIT/Unlicense  | Low-level regex DFAs      |
+| 27 | [regex-syntax]         | [rust-lang]     | Apache-2.0/MIT | Regex syntax impl         |
+| 28 | [rustc-demangle]       | [@alexcrichton] | Apache-2.0/MIT | Symbol demangling         |
+| 29 | [secrecy]              | [iqlusion]      | Apache-2.0     | Secret-keeping types      |
+| 30 | [semver]               | [@steveklabnik] | Apache-2.0/MIT | Semantic versioning       |
+| 31 | [semver-parser]        | [@steveklabnik] | Apache-2.0/MIT | Parser for semver spec    |
+| 32 | [serde]                | [serde-rs]      | Apache-2.0/MIT | Serialization framework   |
+| 33 | [sharded-slab]         | [@hawkw]        | MIT            | Concurrent slab allocator |
+| 34 | [signal-hook]          | [@vorner]       | Apache-2.0/MIT | Unix signal handling      |
+| 35 | [signal-hook-registry] | [@vorner]       | Apache-2.0/MIT | Unix signal registry      |
+| 36 | [smallvec]             | [servo]         | Apache-2.0/MIT | Optimized small vectors   |
+| 37 | [termcolor]            | [@BurntSushi]   | MIT/Unlicense  | Terminal color support    |
+| 38 | [thread_local]         | [@Amanieu]      | Apache-2.0/MIT | Per-object thread local   |
+| 39 | [time]                 | [rust-lang]     | Apache-2.0/MIT | Time/date library         |
+| 40 | [toml]                 | [@alexcrichton] | Apache-2.0/MIT | TOML parser library       |
+| 41 | [tracing]              | [tokio-rs]      | MIT            | App tracing / logging     |
+| 42 | [tracing-core]         | [tokio-rs]      | MIT            | App tracing / logging     |
+| 43 | [tracing-log]          | [tokio-rs]      | MIT            | `log` compatibility       |
+| 44 | [tracing-subscriber]   | [tokio-rs]      | MIT            | Tracing subscribers       |
+| 45 | [utf8-ranges]          | [@BurntSushi]   | MIT/Unlicense  | UTF-8 codepoint ranges    |
+| 46 | [winapi]§              | [@retep998]     | Apache-2.0/MIT | Windows FFI bindings      |
+| 47 | [winapi-util]          | [@BurntSushi]   | MIT/Unlicense  | Safe winapi wrappers      |
+| 48 | [wincolor]             | [@BurntSushi]   | MIT/Unlicense  | Windows console color     |
+| 49 | [zeroize]              | [iqlusion]      | Apache-2.0/MIT | Zero out sensitive data   |
 
 ### Build / Development / Testing Dependencies
 
@@ -230,8 +228,6 @@ so you only compile the parts you need.
 | [signal-hook-registry] | `signals`          | [signal-hook]             |
 | [smallvec]             | `trace`            | [tracing-subscriber]      |
 | [strsim]               | -                  | [darling_core]            |
-| [spin]                 | `testing`, `trace` | [lazy_static], [tracing], [tracing-core] |
-| [stable_deref_trait]   | `trace`            | [owning_ref]              |
 | [syn]                  | -                  | [abscissa_derive], [darling], [gumdrop_derive], [serde_derive] |
 | [termcolor]            | `terminal`         | [abscissa_core]           |
 | [thiserror]            | -                  | Abscissa boilerplate      |
@@ -278,7 +274,7 @@ $ cargo test
 
 However, when debugging test failures against a generated app, it's helpful to
 know how to drive the app generation and testing process manually. Below are
-instructions on how to do so. 
+instructions on how to do so.
 
 If you've already run:
 

--- a/README.md
+++ b/README.md
@@ -211,7 +211,6 @@ so you only compile the parts you need.
 | [num-integer]          | `time`             | [chrono]                  |
 | [num-traits]           | `time`             | [chrono], [num-integer]   |
 | [once_cell]            | -                  | [abscissa_core]           |
-| [owning_ref]           | `trace`            | [tracing-subscriber]      |
 | [proc-macro2]          | -                  | [abscissa_derive], [darling], [quote], [serde_derive], [syn] |
 | [quote]                | -                  | [abscissa_derive], [darling], [gumdrop_derive], [serde_derive] |
 | [redox_syscall]        | `time`             | [time]                    |
@@ -225,6 +224,7 @@ so you only compile the parts you need.
 | [serde]                | `config`           | [abscissa_core]           |
 | [serde_derive]         | `config`           | [serde]                   |
 | [signal-hook]          | `signals`          | [abscissa_core]           |
+| [sharded-slab]         | `trace`            | [tracing-subscriber]      |
 | [signal-hook-registry] | `signals`          | [signal-hook]             |
 | [smallvec]             | `trace`            | [tracing-subscriber]      |
 | [strsim]               | -                  | [darling_core]            |
@@ -405,7 +405,6 @@ read the [CONTRIBUTING.md] and [CODE_OF_CONDUCT.md] files first.
 [num-integer]: https://crates.io/crates/num-integer
 [num-traits]: https://crates.io/crates/num-traits
 [once_cell]: https://crates.io/crates/once_cell
-[owning_ref]: https://crates.io/crates/owning_ref
 [proc-macro2]: https://crates.io/crates/proc-macro2
 [quote]: https://crates.io/crates/quote
 [redox_syscall]: https://crates.io/crates/redox_syscall
@@ -418,11 +417,10 @@ read the [CONTRIBUTING.md] and [CODE_OF_CONDUCT.md] files first.
 [semver-parser]: https://crates.io/crates/semver-parser
 [serde]: https://crates.io/crates/serde
 [serde_derive]: https://crates.io/crates/serde_derive
+[sharded-slab]: https://crates.io/crates/sharded-slab
 [signal-hook]: https://crates.io/crates/signal-hook
 [signal-hook-registry]: https://crates.io/crates/signal-hook
 [smallvec]: https://crates.io/crates/smallvec
-[spin]: https://crates.io/crates/spin
-[stable_deref_trait]: https://crates.io/crates/stable_deref_trait
 [strsim]: https://crates.io/crates/strsim
 [syn]: https://crates.io/crates/syn
 [synstructure]: https://crates.io/crates/synstructure

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -35,7 +35,7 @@ termcolor = { version = "1", optional = true }
 toml = { version = "0.5", optional = true }
 tracing = { version = "0.1", optional = true }
 tracing-log = { version = "0.1", optional = true }
-tracing-subscriber = { version = "0.1", optional = true }
+tracing-subscriber = { version = "0.2", optional = true, default-features = false, features = ["fmt", "env-filter", "ansi", "smallvec", "tracing-log"] }
 wait-timeout = { version = "0.2", optional = true }
 
 [target.'cfg(unix)'.dependencies]


### PR DESCRIPTION
This branch updates the `tracing-subscriber` dependency to version
0.2.0. This is a major release which includes a couple of important bug
fixes; in particular, we've fixed a memory leak caused by spans failing
to close their parents, and made significant improvements to performance
under high concurrency.

Since this is also a potentially breaking change, I'm trying to help
some of our major dependents update by opening PRs against projects that
use `tracing-subscriber`. However, it looks like Abscissa didn't
actually use any of the APIs we broke in this release :)

Additionally, while I'm here, I took the liberty of updating the
dependency list in the README to reflect changes in transitive
dependencies pulled in by `tracing-subscriber` and `tracing`. Several
dependencies were removed — in particular, the dependency on `spin` —
and a couple were added, but I'm happy to note that the `tracing` update
has a net-negative impact on Abscissa's total number of dependencies.
Hopefully this is helpful!