### PR TITLE
tokio: Initial `abscissa_tokio` crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -51,6 +51,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "abscissa_tokio"
+version = "0.5.0-pre"
+dependencies = [
+ "abscissa_core",
+ "futures-util",
+ "tokio",
+]
+
+[[package]]
 name = "addr2line"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -168,6 +177,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7c3dd8985a7111efc5c80b44e23ecdd8c007de8ade3b96595387e812b957cf5"
 
 [[package]]
+name = "bytes"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "130aac562c0dd69c56b3b1cc8ffd2e17be31d0b6c25b61c96b76231aa23e39e1"
+
+[[package]]
 name = "canonical-path"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -279,6 +294,29 @@ name = "fnv"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2fad85553e09a6f881f739c29f0b00b0f01357c743266d478b68951ce23285f3"
+
+[[package]]
+name = "futures-core"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f25592f769825e89b92358db00d26f965761e094951ac44d3663ef25b7ac464a"
+
+[[package]]
+name = "futures-task"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b0a34e53cf6cdcd0178aa573aed466b646eb3db769570841fda0c7ede375a27"
+
+[[package]]
+name = "futures-util"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22766cf25d64306bedf0384da004d05c9974ab104fcc4528f1236181c18004c5"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "pin-utils",
+]
 
 [[package]]
 name = "generational-arena"
@@ -510,6 +548,18 @@ dependencies = [
  "pest",
  "sha-1",
 ]
+
+[[package]]
+name = "pin-project-lite"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "237844750cfbb86f67afe27eee600dfbbcb6188d734139b534cbfbf4f96792ae"
+
+[[package]]
+name = "pin-utils"
+version = "0.1.0-alpha.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5894c618ce612a3fa23881b152b608bafb8c56cfc22f434a3ba3120b40f7b587"
 
 [[package]]
 name = "plain"
@@ -783,6 +833,16 @@ dependencies = [
  "libc",
  "redox_syscall",
  "winapi",
+]
+
+[[package]]
+name = "tokio"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fdd17989496f49cdc57978c96f0c9fe5e4a58a8bddc6813c449a4624f6a030b"
+dependencies = [
+ "bytes",
+ "pin-project-lite",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,2 +1,2 @@
 [workspace]
-members = ["core", "cli", "derive"]
+members = ["core", "cli", "derive", "tokio"]

--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ Abscissa presently consists of three crates:
 - [abscissa]: CLI app and application generator - `cargo install abscissa`
 - [abscissa_core]: main framework library
 - [abscissa_derive]: custom derive support - implementation detail of `abscissa_core`
+- [abscissa_tokio]: support for launching Tokio runtimes within Abscissa applications
 
 ## Requirements
 
@@ -375,6 +376,7 @@ read the [CONTRIBUTING.md] and [CODE_OF_CONDUCT.md] files first.
 [abscissa]: https://crates.io/crates/abscissa
 [abscissa_core]: https://crates.io/crates/abscissa_core
 [abscissa_derive]: https://crates.io/crates/abscissa_derive
+[abscissa_tokio]: https://crates.io/crates/abscissa_tokio
 [aho-corasick]: https://crates.io/crates/aho-corasick
 [ansi_term]: https://crates.io/crates/ansi-term
 [arc-swap]: https://crates.io/crates/arc-swap

--- a/derive/README.md
+++ b/derive/README.md
@@ -37,8 +37,8 @@ limitations under the License.
 
 [crate-image]: https://img.shields.io/crates/v/abscissa_derive.svg
 [crate-link]: https://crates.io/crates/abscissa_derive
-[docs-image]: https://docs.rs/abscissa/badge.svg
-[docs-link]: https://docs.rs/abscissa/
+[docs-image]: https://docs.rs/abscissa_core/badge.svg
+[docs-link]: https://docs.rs/abscissa_core/
 [license-image]: https://img.shields.io/badge/license-Apache2.0-blue.svg
 [license-link]: https://github.com/iqlusioninc/abscissa/blob/develop/LICENSE
 [build-image]: https://github.com/iqlusioninc/abscissa/workflows/Rust/badge.svg?branch=develop&event=push

--- a/tokio/Cargo.toml
+++ b/tokio/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name        = "abscissa_tokio"
+description = "Support for launching Tokio runtimes within Abscissa applications"
+version     = "0.5.0-pre" # Also update html_root_url in lib.rs when bumping this
+license     = "Apache-2.0"
+authors     = ["Tony Arcieri <tony@iqlusion.io>"]
+edition     = "2018"
+homepage    = "https://github.com/iqlusioninc/abscissa"
+repository  = "https://github.com/iqlusioninc/abscissa/tree/develop/abscissa_tokio"
+readme      = "README.md"
+
+[badges]
+maintenance = { status = "actively-developed" }
+
+[dependencies]
+abscissa_core = { version = "0.5", path = "../core" }
+futures-util = { version = "0.3", default-features = false }
+tokio = { version = "0.2", default-features = false }

--- a/tokio/README.md
+++ b/tokio/README.md
@@ -1,0 +1,70 @@
+![Abscissa](https://www.iqlusion.io/img/github/iqlusioninc/abscissa/abscissa.svg)
+
+# abscissa_tokio: Tokio component for Abscissa
+
+[![Crate][crate-image]][crate-link]
+[![Docs][docs-image]][docs-link]
+[![Apache 2.0 Licensed][license-image]][license-link]
+[![Build Status][build-image]][build-link]
+
+Support for launching [Tokio] runtimes within [Abscissa] applications.
+
+[Documentation][docs-link]
+
+## About
+
+Where normally you'd use something like the [`tokio::main`] macro to launch
+the Tokio runtime, in Abscissa the framework is launched by calling
+[`abscissa_core::boot`] from your application's `main()`.
+
+This means Abscissa applications need a slightly different convention for
+starting the Tokio runtime, and ideally one which allows all application
+subcomponents to register themselves before the runtime is started.
+
+This crate handles instantiating the Tokio runtime as an Abscissa [Component],
+allowing other application components to express they have a Tokio dependency
+so Abscissa can inject the Tokio component as a dependency.
+
+Once the application has booted and all subcomponents have been registered with
+the Tokio runtime, it allows (any of) your application's `Runnable` types to
+start the runtime without having to hold a lock on application state.
+
+See documentation for usage instructions.
+
+## License
+
+The **abscissa_tokio** crate is distributed under the terms of the
+Apache License (Version 2.0).
+
+Copyright © 2020 iqlusion
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+[//]: # (badges)
+
+[crate-image]: https://img.shields.io/crates/v/abscissa_tokio.svg
+[crate-link]: https://crates.io/crates/abscissa_tokio
+[docs-image]: https://docs.rs/abscissa_tokio/badge.svg
+[docs-link]: https://docs.rs/abscissa_tokio/
+[license-image]: https://img.shields.io/badge/license-Apache2.0-blue.svg
+[license-link]: https://github.com/iqlusioninc/abscissa/blob/develop/LICENSE
+[build-image]: https://github.com/iqlusioninc/abscissa/workflows/Rust/badge.svg?branch=develop&event=push
+[build-link]: https://github.com/iqlusioninc/abscissa/actions
+
+[//]: # (general links)
+
+[Tokio]: https://tokio.rs/
+[Abscissa]: https://github.com/iqlusioninc/abscissa
+[`tokio::main`]: https://docs.rs/tokio/latest/tokio/attr.main.html
+[`abscissa_core::boot`]: https://docs.rs/abscissa_core/latest/abscissa_core/application/fn.boot.html
+[Component]: https://docs.rs/abscissa_core/latest/abscissa_core/component/trait.Component.html

--- a/tokio/src/lib.rs
+++ b/tokio/src/lib.rs
@@ -1,0 +1,185 @@
+//! Support for launching [Tokio] runtimes within Abscissa applications.
+//!
+//! # About
+//!
+//! Where normally you'd use something like the [`tokio::main`]
+//! macro to launch the Tokio runtime, in Abscissa the framework is launched by
+//! calling [`abscissa_core::boot`] from your application's `main()`.
+//!
+//! This means Abscissa applications need a slightly different convention for
+//! starting the Tokio runtime, and ideally one which allows all application
+//! subcomponents to register themselves before the runtime is started.
+//!
+//! This crate handles instantiating the Tokio runtime as an Abscissa [`Component`],
+//! allowing other application components to express they have a Tokio dependency
+//! so Abscissa can inject the Tokio component as a dependency.
+//!
+//! # Requirements
+//!
+//! - Rust 1.39+
+//! - Abscissa 0.5
+//! - Tokio 0.2
+//!
+//! # Usage
+//!
+//! ## Defining Abscissa components that depends on Tokio
+//!
+//! To register an Abscissa component with the Tokio runtime, add
+//! [`TokioComponent`] as a dependency to be injected when the runtime
+//! is available:
+//!
+//! ```
+//! use abscissa_core::{Component, FrameworkError};
+//! use abscissa_tokio::TokioComponent;
+//!
+//! #[derive(Component, Debug)]
+//! #[component(inject = "init_tokio(abscissa_tokio::TokioComponent)")]
+//! pub struct MyComponent {}
+//!
+//! impl MyComponent {
+//!     pub fn new() -> Result<Self, FrameworkError> {
+//!         Ok(Self {})
+//!     }
+//!
+//!     /// Called automatically after `TokioComponent` is initialized
+//!     pub fn init_tokio(&mut self, tokio_cmp: &TokioComponent) -> Result<(), FrameworkError> {
+//!         // Register with the Tokio runtime here, e.g.:
+//!         // `tokio_cmp.runtime()?.spawn(async move { ... });`
+//!         Ok(())
+//!     }
+//! }
+//! ```
+//!
+//! ## Add `TokioComponent` to your Abscissa application
+//!
+//! Inside of your app's `application.rs`, find the [`register_components`]
+//! method and add [`TokioComponent`]:
+//!
+//! ```text
+//! fn register_components(&mut self, command: &Self::Cmd) -> Result<(), FrameworkError> {
+//!     let mut components = self.framework_components(command)?;
+//!
+//!     // Create `TokioComponent` and add it to your app's components here:
+//!     use abscissa_tokio::TokioComponent;
+//!     components.push(Box::new(TokioComponent::new()?));
+//!
+//!     self.state.components.register(components)
+//! }
+//! ```
+//!
+//! Inside of the [`Runnable`] for one of your application's subcommands, call
+//! [`abscissa_tokio::start`] to launch the Tokio runtime:
+//!
+//! ```text
+//! impl Runnable for StartCmd {
+//!    fn run(&self) {
+//!        abscissa_tokio::start(&crate::application::APPLICATION);
+//!    }
+//! }
+//! ```
+//!
+//! This will run any futures which were registered
+//!
+//! [Tokio]: https://tokio.rs
+//! [`tokio::main`]: https://docs.rs/tokio/latest/tokio/attr.main.html
+//! [`abscissa_core::boot`]: https://docs.rs/abscissa_core/latest/abscissa_core/application/fn.boot.html
+//! [`Component`]: https://docs.rs/abscissa_core/latest/abscissa_core/component/trait.Component.html
+//! [`TokioComponent`]: https://docs.rs/abscissa_tokio/latest/abscissa_tokio/struct.TokioComponent.html
+//! [`register_components`]: https://docs.rs/abscissa_core/latest/abscissa_core/application/trait.Application.html#tymethod.register_components
+//! [`Runnable`]: https://docs.rs/abscissa_core/latest/abscissa_core/trait.Runnable.html
+//! [`abscissa_tokio::start`]: https://docs.rs/abscissa_tokio/latest/abscissa_tokio/application/fn.start.html
+
+#![doc(
+    html_logo_url = "https://www.iqlusion.io/img/github/iqlusioninc/abscissa/abscissa-sq.svg",
+    html_root_url = "https://docs.rs/abscissa_tokio/0.5.0-pre"
+)]
+#![forbid(unsafe_code)]
+#![warn(rust_2018_idioms, unused_lifetimes, unused_qualifications)]
+
+pub use tokio;
+
+use abscissa_core::{
+    application::{AppCell, Application},
+    format_err, Component, FrameworkError, FrameworkErrorKind,
+};
+use futures_util::future;
+use tokio::runtime::Runtime;
+
+/// Start the Tokio runtime within the given application.
+///
+/// Panics if the runtime is unavailable or has already been started.
+pub fn start<A: Application>(app_cell: &'static AppCell<A>) {
+    let mut runtime = app_cell
+        .write()
+        .state_mut()
+        .components
+        .get_downcast_mut::<TokioComponent>()
+        .expect("TokioComponent not registered!")
+        .runtime
+        .take()
+        .expect("Tokio runtime has already been started!");
+
+    runtime.block_on(future::pending::<()>())
+}
+
+/// Component which manages initialization of a Tokio runtime within the
+/// Abscissa application lifecycle.
+///
+/// See this crate's [toplevel documentation](index.html) for detailed usage notes.
+#[derive(Component, Debug)]
+pub struct TokioComponent {
+    runtime: Option<Runtime>,
+}
+
+impl TokioComponent {
+    /// Create a new Tokio runtime component with the default options
+    pub fn new() -> Result<Self, FrameworkError> {
+        Runtime::new().map(From::from).map_err(|e| {
+            format_err!(
+                FrameworkErrorKind::ComponentError,
+                "couldn't start Tokio runtime: {}",
+                e
+            )
+            .into()
+        })
+    }
+
+    /// Borrow the runtime, to e.g. `::spawn` a future on it.
+    ///
+    /// Returns an error if the runtime has already been taken.
+    pub fn runtime(&self) -> Result<&Runtime, FrameworkError> {
+        self.runtime.as_ref().ok_or_else(|| {
+            format_err!(
+                FrameworkErrorKind::ComponentError,
+                "Tokio runtime has already been taken!"
+            )
+            .into()
+        })
+    }
+
+    /// Borrow the runtime mutably (e.g. to `block_on` it during startup).
+    ///
+    /// NOTE: If you are trying to transfer control of your application to the
+    /// Tokio runtime, use the [`abscissa_tokio::start`] function instead.
+    ///
+    /// Returns an error if the runtime has already been taken.
+    ///
+    /// [`abscissa_tokio::start`]: https://docs.rs/abscissa_tokio/latest/abscissa_tokio/application/fn.start.html
+    pub fn runtime_mut(&mut self) -> Result<&mut Runtime, FrameworkError> {
+        self.runtime.as_mut().ok_or_else(|| {
+            format_err!(
+                FrameworkErrorKind::ComponentError,
+                "Tokio runtime has already been taken!"
+            )
+            .into()
+        })
+    }
+}
+
+impl From<Runtime> for TokioComponent {
+    fn from(runtime: Runtime) -> Self {
+        Self {
+            runtime: Some(runtime),
+        }
+    }
+}


### PR DESCRIPTION
Adds an `abscissa_tokio` crate containing a `TokioComponent` which manages the lifecycle for spawning a `tokio::runtime::Runtime`.

Inspired by the approach used in Zebrad:

https://github.com/ZcashFoundation/zebra/blob/4fcb550/zebrad/src/components/tokio.rs

cc @hdevalence @dconnolly