### PR TITLE
cli: rename `APPLICATION` -> `APP`; export from prelude; redo helpers

### DIFF
--- a/cli/src/application.rs
+++ b/cli/src/application.rs
@@ -7,7 +7,7 @@ use abscissa_core::{
 };
 
 /// Application state
-pub static APPLICATION: AppCell<CliApplication> = AppCell::new();
+pub static APP: AppCell<CliApplication> = AppCell::new();
 
 /// Abscissa CLI Application
 #[derive(Debug)]

--- a/cli/src/bin/abscissa/main.rs
+++ b/cli/src/bin/abscissa/main.rs
@@ -3,9 +3,9 @@
 #![deny(warnings, missing_docs, trivial_casts, unused_qualifications)]
 #![forbid(unsafe_code)]
 
-use abscissa::application::APPLICATION;
+use abscissa::application::APP;
 
 /// Boot Abscissa CLI
 fn main() {
-    abscissa_core::boot(&APPLICATION);
+    abscissa_core::boot(&APP);
 }

--- a/cli/template/src/application.rs.hbs
+++ b/cli/template/src/application.rs.hbs
@@ -3,30 +3,11 @@
 use crate::{commands::{{~command_type~}}, config::{{~config_type~}}};
 use abscissa_core::{
     application::{self, AppCell},
-    config, trace, Application, EntryPoint, FrameworkError, StandardPaths,
+    trace, Application, EntryPoint, FrameworkError, StandardPaths,
 };
 
 /// Application state
-pub static APPLICATION: AppCell<{{~application_type~}}> = AppCell::new();
-
-/// Obtain a read-only (multi-reader) lock on the application state.
-///
-/// Panics if the application state has not been initialized.
-pub fn app_reader() -> application::lock::Reader<{{~application_type~}}> {
-    APPLICATION.read()
-}
-
-/// Obtain an exclusive mutable lock on the application state.
-pub fn app_writer() -> application::lock::Writer<{{~application_type~}}> {
-    APPLICATION.write()
-}
-
-/// Obtain a read-only (multi-reader) lock on the application configuration.
-///
-/// Panics if the application configuration has not been loaded.
-pub fn app_config() -> config::Reader<{{~application_type~}}> {
-    config::Reader::new(&APPLICATION)
-}
+pub static APP: AppCell<{{~application_type~}}> = AppCell::new();
 
 /// {{title}} Application
 #[derive(Debug)]

--- a/cli/template/src/bin/app/main.rs.hbs
+++ b/cli/template/src/bin/app/main.rs.hbs
@@ -3,9 +3,9 @@
 #![deny(warnings, missing_docs, trivial_casts, unused_qualifications)]
 #![forbid(unsafe_code)]
 
-use {{name}}::application::APPLICATION;
+use {{name}}::application::APP;
 
 /// Boot {{title}}
 fn main() {
-    abscissa_core::boot(&APPLICATION);
+    abscissa_core::boot(&APP);
 }

--- a/cli/template/src/commands/start.rs.hbs
+++ b/cli/template/src/commands/start.rs.hbs
@@ -24,7 +24,7 @@ pub struct StartCmd {
 impl Runnable for StartCmd {
     /// Start the application.
     fn run(&self) {
-        let config = app_config();
+        let config = APP.config();
         println!("Hello, {}!", &config.hello.recipient);
     }
 }

--- a/cli/template/src/prelude.rs.hbs
+++ b/cli/template/src/prelude.rs.hbs
@@ -5,5 +5,5 @@
 /// Abscissa core prelude
 pub use abscissa_core::prelude::*;
 
-/// Application state accessors
-pub use crate::application::{app_config, app_reader, app_writer};
+/// Application state
+pub use crate::application::APP;

--- a/core/src/application/cell.rs
+++ b/core/src/application/cell.rs
@@ -4,6 +4,7 @@ use super::{
     lock::{Lock, Reader, Writer},
     Application,
 };
+use crate::config;
 use once_cell::sync::OnceCell;
 
 /// Newtype wrapper for the cell type we use.
@@ -45,6 +46,13 @@ impl<A: Application> AppCell<A> {
     /// accessed mutably.
     pub fn write(&'static self) -> Writer<A> {
         self.0.get().unwrap_or_else(|| not_loaded()).write()
+    }
+
+    /// Obtain a read-only (multi-reader) lock on the application configuration.
+    ///
+    /// Panics if the application configuration has not been loaded.
+    pub fn config(&'static self) -> config::Reader<A> {
+        config::Reader::new(self)
     }
 }
 

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -68,7 +68,7 @@
 //!
 //! # Status Macros
 //!
-//! ```norun
+//! ```ignore
 //! // Print a Cargo-like justified status to STDOUT
 //! status_ok!("Loaded", "app loaded successfully");
 //!

--- a/core/src/terminal/status.rs
+++ b/core/src/terminal/status.rs
@@ -5,28 +5,28 @@
 //!
 //! # `status_ok!`: Successful status messages
 //!
-//! ```norun
+//! ```ignore
 //! // Print a Cargo-like justified status to STDOUT
 //! status_ok!("Loaded", "app loaded successfully");
 //! ```
 //!
 //! # `status_err!`: Error messages
 //!
-//! ```norun
+//! ```ignore
 //! // Print an error message
 //! status_err!("something bad happened");
 //! ```
 //!
 //! # `status_attr_ok!`: Successful attributes
 //!
-//! ```norun
+//! ```ignore
 //! // Print an indented attribute to STDOUT
 //! status_attr_ok!("good", "yep");
 //! ```
 //!
 //! # `status_attr_error!`: Error attributes
 //!
-//! ```norun
+//! ```ignore
 //! // Print an error attribute to STDERR
 //! status_attr_err!("error", "yep");
 //! ```
@@ -38,12 +38,9 @@ use termcolor::{Color, ColorSpec, StandardStream, WriteColor};
 
 /// Print a success status message (in green if colors are enabled)
 ///
-/// ```norun
-/// # #[macro_use] extern crate abscissa;
-/// # fn main() {
+/// ```ignore
 /// // Print a Cargo-like justified status to STDOUT
 /// status_ok!("Loaded", "app loaded successfully");
-/// # }
 /// ```
 #[macro_export]
 macro_rules! status_ok {
@@ -63,12 +60,9 @@ macro_rules! status_ok {
 
 /// Print an informational status message (in cyan if colors are enabled)
 ///
-/// ```norun
-/// # #[macro_use] extern crate abscissa;
-/// # fn main() {
+/// ```ignore
 /// // Print a Cargo-like justified status to STDOUT
 /// status_info!("Info", "you may care to know about");
-/// # }
 /// ```
 #[macro_export]
 macro_rules! status_info {
@@ -88,12 +82,9 @@ macro_rules! status_info {
 
 /// Print a warning status message (in yellow if colors are enabled)
 ///
-/// ```norun
-/// # #[macro_use] extern crate abscissa;
-/// # fn main() {
+/// ```ignore
 /// // Print a Cargo-like justified status to STDOUT
 /// status_warn!("heads up, there's something you should know");
-/// # }
 /// ```
 #[macro_export]
 macro_rules! status_warn {
@@ -112,12 +103,9 @@ macro_rules! status_warn {
 
 /// Print an error message (in red if colors are enabled)
 ///
-/// ```norun
-/// # #[macro_use] extern crate abscissa;
-/// # fn main() {
+/// ```ignore
 /// // Print an error message
 /// status_err!("something bad happened");
-/// # }
 /// ```
 #[macro_export]
 macro_rules! status_err {
@@ -136,12 +124,9 @@ macro_rules! status_err {
 
 /// Print a tab-delimited status attribute (in green if colors are enabled)
 ///
-/// ```norun
-/// # #[macro_use] extern crate abscissa;
-/// # fn main() {
+/// ```ignore
 /// // Print an indented attribute to STDOUT
 /// status_attr_ok!("good", "yep");
-/// # }
 /// ```
 #[macro_export]
 macro_rules! status_attr_ok {
@@ -168,12 +153,9 @@ macro_rules! status_attr_ok {
 
 /// Print a tab-delimited status attribute (in red if colors are enabled)
 ///
-/// ```norun
-/// # #[macro_use] extern crate abscissa;
-/// # fn main() {
+/// ```ignore
 /// // Print an error attribute to STDERR
 /// status_attr_err!("error", "yep");
-/// # }
 /// ```
 #[macro_export]
 macro_rules! status_attr_err {

--- a/tokio/src/lib.rs
+++ b/tokio/src/lib.rs
@@ -72,11 +72,11 @@
 //! [`abscissa_tokio::run`] with a provided [`Future`] to launch the Tokio runtime:
 //!
 //! ```ignore
-//! use crate::application::APPLICATION;
+//! use crate::application::APP;
 //!
 //! impl Runnable for StartCmd {
 //!    fn run(&self) {
-//!        abscissa_tokio::run(&APPLICATION, async {
+//!        abscissa_tokio::run(&APP, async {
 //!            println!("now running inside the Tokio runtime");
 //!        });
 //!    }


### PR DESCRIPTION
- Shortens `APPLICATION` constant to `APP` in the template
- Re-exports `APP` via the app-local prelude
- Adds a `config()` method to `AppCell`
- Removes the `app_reqder()`, `app_writer()`, `app_config()` helpers; Use `APP.read()`, `APP.write()`, `APP.config()` instead