### PR TITLE
Fix wrong method name in doc comment

### DIFF
--- a/core/src/command.rs
+++ b/core/src/command.rs
@@ -14,7 +14,7 @@ use std::fmt::Debug;
 use termcolor::ColorChoice;
 
 /// Subcommand of an application: derives or otherwise implements the `Options`
-/// trait, but also has a `call()` method which can be used to invoke the given
+/// trait, but also has a `run()` method which can be used to invoke the given
 /// (sub)command.
 pub trait Command: Debug + Options + Runnable {
     /// Name of this program as a string


### PR DESCRIPTION
The doc comment in question refers to a method named `call`, which does not exist anywhere within the code for Abscissa. The comment is most likely trying to refer to the `run` method, which is required by the `Runnable` trait.

I assume this was overlooked when the `Callable` trait was renamed to `Runnable`.