### PR TITLE
Replace gumdrop with clap v3 (beta 1)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5,7 +5,7 @@ name = "abscissa"
 version = "0.5.1"
 dependencies = [
  "abscissa_core",
- "gumdrop",
+ "clap",
  "handlebars",
  "ident_case",
  "once_cell",
@@ -20,9 +20,9 @@ dependencies = [
  "backtrace",
  "canonical-path",
  "chrono",
+ "clap",
  "color-backtrace",
  "generational-arena",
- "gumdrop",
  "libc",
  "once_cell",
  "regex",
@@ -114,6 +114,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d49d90015b3c36167a20fe2810c5cd875ad504b39cff3d4eae7977e6b7c1cb2"
 
 [[package]]
+name = "autocfg"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8aac770f1885fd7e387acedd76065302551364496e46b3dd00860b2f8359b9d"
+
+[[package]]
 name = "backtrace"
 version = "0.3.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -126,6 +132,12 @@ dependencies = [
  "object",
  "rustc-demangle",
 ]
+
+[[package]]
+name = "bitflags"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
 
 [[package]]
 name = "block-buffer"
@@ -191,6 +203,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap"
+version = "3.0.0-beta.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "860643c53f980f0d38a5e25dfab6c3c93b2cb3aa1fe192643d17a293c6c41936"
+dependencies = [
+ "atty",
+ "bitflags",
+ "clap_derive",
+ "indexmap",
+ "lazy_static",
+ "os_str_bytes",
+ "strsim 0.10.0",
+ "termcolor",
+ "textwrap",
+ "unicode-width",
+ "vec_map",
+]
+
+[[package]]
+name = "clap_derive"
+version = "3.0.0-beta.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb51c9e75b94452505acd21d929323f5a5c6c4735a852adbd39ef5fb1b014f30"
+dependencies = [
+ "heck",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "color-backtrace"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -221,7 +265,7 @@ dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
- "strsim",
+ "strsim 0.9.2",
  "syn",
 ]
 
@@ -282,26 +326,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aaf91faf136cb47367fa430cd46e37a788775e7fa104f8b4bcb3861dc389b724"
 
 [[package]]
-name = "gumdrop"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee50908bc1beeac1f2902e0b4e0cd0d844e716f5ebdc6f0cfc1163fe5e10bcde"
-dependencies = [
- "gumdrop_derive",
-]
-
-[[package]]
-name = "gumdrop_derive"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90454ce4de40b7ca6a8968b5ef367bdab48413962588d0d2b1638d60090c35d7"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "handlebars"
 version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -316,10 +340,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34f595585f103464d8d2f6e9864682d74c1601fed5e07d62b1c9058dba8246fb"
+dependencies = [
+ "autocfg 1.0.0",
+]
+
+[[package]]
+name = "heck"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20564e78d53d2bb135c343b3f47714a56af2061f1c928fdb541dc7b9fdd94205"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
 name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
+name = "indexmap"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b88cd59ee5f71fea89a62248fc8f387d44400cefe05ef548466d61ced9029a7"
+dependencies = [
+ "autocfg 1.0.0",
+ "hashbrown",
+]
 
 [[package]]
 name = "itoa"
@@ -384,7 +436,7 @@ version = "0.1.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b85e541ef8255f6cf42bbfe4ef361305c6c135d10919ecc26126c4e5ae94bc09"
 dependencies = [
- "autocfg",
+ "autocfg 0.1.7",
  "num-traits",
 ]
 
@@ -394,7 +446,7 @@ version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4c81ffc11c212fa327657cb19dd85eb7419e163b5b076bede2bdb5c974c07e4"
 dependencies = [
- "autocfg",
+ "autocfg 0.1.7",
 ]
 
 [[package]]
@@ -414,6 +466,12 @@ name = "opaque-debug"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2839e79665f131bdb5782e51f2c6c9599c133c6098982a54c794358bf432529c"
+
+[[package]]
+name = "os_str_bytes"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ac6fe3538f701e339953a3ebbe4f39941aababa8a3f6964635b24ab526daeac"
 
 [[package]]
 name = "pest"
@@ -463,6 +521,32 @@ name = "pin-project-lite"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "237844750cfbb86f67afe27eee600dfbbcb6188d734139b534cbfbf4f96792ae"
+
+[[package]]
+name = "proc-macro-error"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18f33027081eba0a6d8aba6d1b1c3a3be58cbb12106341c2d5759fcd9b5277e7"
+dependencies = [
+ "proc-macro-error-attr",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "version_check",
+]
+
+[[package]]
+name = "proc-macro-error-attr"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a5b4b77fdb63c1eca72173d68d24501c54ab1269409f6b672c85deb18af69de"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "syn-mid",
+ "version_check",
+]
 
 [[package]]
 name = "proc-macro2"
@@ -640,6 +724,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "032c03039aae92b350aad2e3779c352e104d919cb192ba2fabbd7b831ce4f0f6"
 
 [[package]]
+name = "strsim"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
 name = "syn"
 version = "1.0.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -648,6 +738,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-xid",
+]
+
+[[package]]
+name = "syn-mid"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7be3539f6c128a931cf19dcee741c1af532c7fd387baa739c03dd2e96479338a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -669,6 +770,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb6bfa289a4d7c5766392812c0a1f4c1ba45afa1ad47803c11e1f407d846d75f"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "textwrap"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
+dependencies = [
+ "unicode-width",
 ]
 
 [[package]]
@@ -780,6 +890,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f00ed7be0c1ff1e24f46c3d2af4859f7e863672ba3a6e92e7cff702bf9f06c2"
 
 [[package]]
+name = "unicode-segmentation"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e83e153d1053cbb5a118eeff7fd5be06ed99153f00dbcd8ae310c5fb2b22edc0"
+
+[[package]]
+name = "unicode-width"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9337591893a19b88d8d87f2cec1e73fad5cdfd10e5a6f349f498ad6ea2ffb1e3"
+
+[[package]]
 name = "unicode-xid"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -790,6 +912,18 @@ name = "utf8-ranges"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4ae116fef2b7fea257ed6440d3cfcff7f190865f170cdad00bb6465bf18ecba"
+
+[[package]]
+name = "vec_map"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
+
+[[package]]
+name = "version_check"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5a972e5669d67ba988ce3dc826706fb0a8b01471c088cb0b6110b805cc36aed"
 
 [[package]]
 name = "wait-timeout"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -19,7 +19,7 @@ keywords    = ["abscissa", "cli", "application", "framework", "service"]
 maintenance = { status = "actively-developed" }
 
 [dependencies]
-gumdrop = "0.7"
+clap = "3.0.0-beta.1"
 handlebars = "3"
 ident_case = "1"
 serde = { version = "1", features = ["serde_derive"] }

--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -6,22 +6,23 @@ pub mod version;
 
 use self::{gen::GenCommand, new::NewCommand, version::VersionCommand};
 use super::config::CliConfig;
-use abscissa_core::{Command, Configurable, Help, Options, Runnable};
+use abscissa_core::{Command, Configurable, Help, Runnable};
 use std::path::PathBuf;
+use clap::Clap;
 
 /// Abscissa CLI Subcommands
-#[derive(Command, Debug, Options, Runnable)]
+#[derive(Command, Debug, Clap, Runnable)]
 pub enum CliCommand {
-    #[options(help = "generate a new module in an existing app")]
+    #[clap(help = "generate a new module in an existing app")]
     Gen(GenCommand),
 
-    #[options(help = "show help for a command")]
+    #[clap(help = "show help for a command")]
     Help(Help<Self>),
 
-    #[options(help = "create a new Abscissa application from a template")]
+    #[clap(help = "create a new Abscissa application from a template")]
     New(NewCommand),
 
-    #[options(help = "display version information")]
+    #[clap(help = "display version information")]
     Version(VersionCommand),
 }
 

--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -7,8 +7,8 @@ pub mod version;
 use self::{gen::GenCommand, new::NewCommand, version::VersionCommand};
 use super::config::CliConfig;
 use abscissa_core::{Command, Configurable, Help, Runnable};
-use std::path::PathBuf;
 use clap::Clap;
+use std::path::PathBuf;
 
 /// Abscissa CLI Subcommands
 #[derive(Command, Debug, Clap, Runnable)]

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -25,7 +25,7 @@ canonical-path = "2"
 chrono = { version = "0.4", optional = true, features = ["serde"] }
 color-backtrace = { version = "0.4", optional = true, default-features = false }
 generational-arena = { version = "0.2", optional = true }
-gumdrop = { version = "0.7", optional = true }
+clap = { version = "3.0.0-beta.1", optional = true }
 once_cell = "1.4"
 regex = { version = "1", optional = true }
 secrecy = { version = "0.7", optional = true, features = ["serde"] }
@@ -69,7 +69,7 @@ gimli-backtrace = [
     "color-backtrace/gimli-symbolize"
 ]
 trace = ["tracing", "tracing-log", "tracing-subscriber"]
-options = ["gumdrop"]
+options = ["clap"]
 secrets = ["secrecy"]
 signals = ["libc", "signal-hook"]
 terminal = ["color-backtrace", "termcolor"]

--- a/core/src/command.rs
+++ b/core/src/command.rs
@@ -9,9 +9,9 @@ pub use self::{entrypoint::EntryPoint, help::Help, usage::Usage};
 pub use abscissa_derive::Command;
 
 use crate::{runnable::Runnable, terminal};
+use clap::Subcommand;
 use std::fmt::Debug;
 use termcolor::ColorChoice;
-use clap::Subcommand;
 
 /// Subcommand of an application: derives or otherwise implements the `Options`
 /// trait, but also has a `run()` method which can be used to invoke the given

--- a/core/src/command.rs
+++ b/core/src/command.rs
@@ -9,14 +9,14 @@ pub use self::{entrypoint::EntryPoint, help::Help, usage::Usage};
 pub use abscissa_derive::Command;
 
 use crate::{runnable::Runnable, terminal};
-use gumdrop::Options;
 use std::fmt::Debug;
 use termcolor::ColorChoice;
+use clap::Subcommand;
 
 /// Subcommand of an application: derives or otherwise implements the `Options`
 /// trait, but also has a `run()` method which can be used to invoke the given
 /// (sub)command.
-pub trait Command: Debug + Options + Runnable {
+pub trait Command: Debug + Subcommand + Runnable {
     /// Name of this program as a string
     fn name() -> &'static str;
 

--- a/core/src/command/entrypoint.rs
+++ b/core/src/command/entrypoint.rs
@@ -2,8 +2,8 @@
 
 use super::{Command, Usage};
 use crate::{Config, Configurable, FrameworkError, Runnable};
-use std::path::PathBuf;
 use clap::{Clap, Subcommand};
+use std::path::PathBuf;
 
 /// Toplevel entrypoint command.
 ///

--- a/core/src/command/entrypoint.rs
+++ b/core/src/command/entrypoint.rs
@@ -1,34 +1,35 @@
 //! Toplevel entrypoint command.
 
 use super::{Command, Usage};
-use crate::{Config, Configurable, FrameworkError, Options, Runnable};
+use crate::{Config, Configurable, FrameworkError, Runnable};
 use std::path::PathBuf;
+use clap::{Clap, Subcommand};
 
 /// Toplevel entrypoint command.
 ///
 /// Handles obtaining toplevel help as well as verbosity settings.
-#[derive(Debug, Options)]
+#[derive(Debug, Clap)]
 pub struct EntryPoint<Cmd>
 where
     Cmd: Command + Runnable,
 {
     /// Path to the configuration file
-    #[options(short = "c", help = "path to configuration file")]
+    #[clap(short = "c", help = "path to configuration file")]
     pub config: Option<PathBuf>,
 
     /// Obtain help about the current command
-    #[options(short = "h", help = "print help message")]
+    #[clap(short = "h", help = "print help message", parse(try_from_str))]
     pub help: bool,
 
     /// Increase verbosity setting
-    #[options(short = "v", help = "be verbose")]
+    #[clap(short = "v", help = "be verbose", parse(try_from_str))]
     pub verbose: bool,
 
     /// Subcommand to execute.
     ///
     /// The `command` option will delegate option parsing to the command type,
     /// starting at the first free argument.
-    #[options(command)]
+    #[clap(subcommand)]
     pub command: Option<Cmd>,
 }
 

--- a/core/src/command/help.rs
+++ b/core/src/command/help.rs
@@ -2,7 +2,6 @@
 
 use super::Command;
 use crate::runnable::Runnable;
-use gumdrop::{Error, Opt, Options, Parser};
 use std::marker::PhantomData;
 
 /// Help command which prints usage information.
@@ -37,47 +36,47 @@ where
         C::authors()
     }
 }
-
-impl<C> Options for Help<C>
-where
-    C: Command,
-{
-    fn parse<S: AsRef<str>>(parser: &mut Parser<'_, S>) -> Result<Self, Error> {
-        let mut opts = vec![];
-
-        while let Some(opt) = parser.next_opt() {
-            match opt {
-                Opt::Free(free_opt) => opts.push(free_opt.to_owned()),
-                _ => return Err(Error::unexpected_argument(opt)),
-            }
-        }
-
-        Ok(Self {
-            opts,
-            command: PhantomData,
-        })
-    }
-
-    fn parse_command<S: AsRef<str>>(
-        _name: &str,
-        parser: &mut Parser<'_, S>,
-    ) -> Result<Self, Error> {
-        // TODO(tarcieri): is this necessary or the best approach?
-        Self::parse(parser)
-    }
-
-    fn usage() -> &'static str {
-        ""
-    }
-
-    fn command_usage(_command: &str) -> Option<&'static str> {
-        None
-    }
-
-    fn command_list() -> Option<&'static str> {
-        None
-    }
-}
+//
+// impl<C> Options for Help<C>
+// where
+//     C: Command,
+// {
+//     fn parse<S: AsRef<str>>(parser: &mut Parser<'_, S>) -> Result<Self, Error> {
+//         let mut opts = vec![];
+//
+//         while let Some(opt) = parser.next_opt() {
+//             match opt {
+//                 Opt::Free(free_opt) => opts.push(free_opt.to_owned()),
+//                 _ => return Err(Error::unexpected_argument(opt)),
+//             }
+//         }
+//
+//         Ok(Self {
+//             opts,
+//             command: PhantomData,
+//         })
+//     }
+//
+//     fn parse_command<S: AsRef<str>>(
+//         _name: &str,
+//         parser: &mut Parser<'_, S>,
+//     ) -> Result<Self, Error> {
+//         // TODO(tarcieri): is this necessary or the best approach?
+//         Self::parse(parser)
+//     }
+//
+//     fn usage() -> &'static str {
+//         ""
+//     }
+//
+//     fn command_usage(_command: &str) -> Option<&'static str> {
+//         None
+//     }
+//
+//     fn command_list() -> Option<&'static str> {
+//         None
+//     }
+// }
 
 impl<C> Runnable for Help<C>
 where

--- a/core/src/command/usage.rs
+++ b/core/src/command/usage.rs
@@ -154,7 +154,7 @@ impl Usage {
     }
 
     /// Print information about a usage error
-    pub(super) fn print_error_and_exit(&self, err: gumdrop::Error, args: &[String]) -> ! {
+    pub(super) fn print_error_and_exit(&self, err: clap::Error, args: &[String]) -> ! {
         // TODO(tarcieri): better personalize errors based on args
         if args.is_empty() {
             self.print_info().unwrap();

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -140,7 +140,7 @@ pub mod trace;
 // Proc macros
 
 #[cfg(feature = "options")]
-pub use gumdrop::Options;
+pub use clap::Clap;
 
 // Re-exports
 


### PR DESCRIPTION
closes: #298 

I've started the work to try to replace gumdrop with clap v3. 

- Mostly replace dependencies in Cargo.toml files. Replaced gumdrop (0.7) with clap (3.0.0-beta.1)
- Replaced attributes that used gumdrop `#[option(...` with `#[clap...` since clap supports this with clap_derive
- Replaced some gumdrop Error with clap Error

After replacing these, got stuck on core/src/command/entrypoint.rs where the compilation is failing because changes in the file. Especially the command property of this struct. Couldn't find an equivalent way to replace it with clap. Tried to use the #[clap(subcommand)] attribute on this property but it seems make the compiler not to recognize the Cmd type

```
error[E0412]: cannot find type `Cmd` in this scope
  --> core/src/command/entrypoint.rs:33:25
   |
33 |     pub command: Option<Cmd>,
   |                         ^^^ not found in this scope
```

So I believe this is a good starting point but I believe some more fundamental changes will be required in order to replace gumdrop with clap. Especially things related to help and usage which clap supports. So maybe things that currently exist in abscissa like core/src/command -> entrypoint, help and usage might not need to exist or be refactored quite a bit.

Another challenge is that clap also has a concept of [`App`](https://docs.rs/clap/2.33.1/clap/struct.App.html) but it's more related to command line arguments and the executable, so it might differ from Abscissa's `CliApplication` that can track the `State`.

Anyways, I think we can use this draft PR to have discussions on what is the best way to proceed and I'd be happy to help out with this effort. 

