### PR TITLE
cli/template: fix typo in example comment

### DIFF
--- a/cli/template/src/commands/subcommand.rs.hbs
+++ b/cli/template/src/commands/subcommand.rs.hbs
@@ -17,7 +17,7 @@ pub struct {{name_capital}} {
 
     // Example `--baz` argument with no short version
     // #[options(no_short, help = "baz path")]
-    // baz: Options<PathBuf>
+    // baz: Option<PathBuf>
 
     // "free" arguments don't have an associated flag
     // #[options(free)]


### PR DESCRIPTION
Hi there!

I'm a newbie and this one had my scratching my head for a second.
`Options` is the imported trait.