### PR TITLE
Fix CI, allow clippy::unnecessary_sort_by

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -150,4 +150,4 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: clippy
-          args: -- -D warnings
+          args: -- -A clippy::unnecessary_sort_by -D warnings


### PR DESCRIPTION
https://rust-lang.github.io/rust-clippy/master/index.html#unnecessary_sort_by would've required a `.clone()` which want to avoid on a lifetime return type. 