### PR TITLE
core: add `fs_err` dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,6 +21,7 @@ dependencies = [
  "canonical-path",
  "chrono",
  "color-backtrace",
+ "fs-err",
  "generational-arena",
  "gumdrop",
  "libc",
@@ -259,6 +260,12 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "fs-err"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bcd1163ae48bda72a20ae26d66a04d3094135cadab911cff418ae5e33f253431"
 
 [[package]]
 name = "generational-arena"

--- a/README.md
+++ b/README.md
@@ -97,57 +97,58 @@ dependencies without due consideration.
 Here are all of Abscissa's transitive dependencies when configured with the
 default set of features in the application:
 
-| #  | Crate Name             | Origin          | License        | Description               |
-|----|------------------------|-----------------|----------------|---------------------------|
-| 1  | [abscissa_core]        | [iqlusion]      | Apache-2.0     | Abscissa framework        |
-| 2  | [aho-corasick]         | [@BurntSushi]   | MIT/Unlicense  | Pattern-matching alg      |
-| 3  | [ansi_term]            | [@ogham]        | MIT            | Terminal color libray     |
-| 4  | [arc-swap]             | [@vorner]       | Apache-2.0/MIT | Atomic swap for `Arc`     |
-| 5  | [atty]                 | [@softprops]    | MIT            | Detect TTY presence       |
-| 6  | [autocfg]              | [@cuviper]      | Apache-2.0/MIT | Rust compiler configs     |
-| 7  | [backtrace]            | [@alexcrichton] | Apache-2.0/MIT | Capture stack traces      |
-| 8  | [backtrace-sys]        | [@alexcrichton] | Apache-2.0/MIT | Capture stack traces      |
-| 9  | [byteorder]            | [@BurntSushi]   | MIT/Unlicense  | Byte order conversions    |
-| 10 | [canonical-path]       | [iqlusion]      | Apache-2.0     | Get canonical fs paths    |
-| 11 | [chrono]               | [chronotope]    | Apache-2.0/MIT | Time/date library         |
-| 12 | [color-backtrace]      | [@athre0z]      | Apache-2.0/MIT | Rich colored backtraces   |
-| 13 | [generational-arena]   | [@fitzgen]      | MPL-2.0        | Component allocator       |
-| 14 | [gumdrop]              | [@Murarth]      | Apache-2.0/MIT | Command-line options      |
-| 15 | [lazy_static]          | [rust-lang]     | Apache-2.0/MIT | Heap-allocated statics    |
-| 16 | [libc]                 | [rust-lang]     | Apache-2.0/MIT | C library wrapper         |
-| 17 | [log]                  | [rust-lang]     | Apache-2.0/MIT | Logging facade library    |
-| 18 | [matchers]             | [@hawkw]        | MIT            | Stream regex matching     |
-| 19 | [maybe-uninit]         | [@est31]        | Apache-2.0/MIT | MaybeUninit compat        |
-| 20 | [memchr]               | [@BurntSushi]   | MIT/Unlicense  | Optimized byte search     |
-| 21 | [num-integer]          | [rust-num]      | Apache-2.0/MIT | `Integer` trait           |
-| 22 | [num-traits]           | [rust-num]      | Apache-2.0/MIT | Numeric traits            |
-| 23 | [once_cell]            | [@matklad]      | Apache-2.0/MIT | Single assignment cells   |
-| 24 | [redox_syscall]        | [redox-os]      | MIT            | Redox OS syscall API      |
-| 25 | [regex]                | [rust-lang]     | Apache-2.0/MIT | Regular expressions       |
-| 26 | [regex-automata]       | [@BurntSushi]   | MIT/Unlicense  | Low-level regex DFAs      |
-| 27 | [regex-syntax]         | [rust-lang]     | Apache-2.0/MIT | Regex syntax impl         |
-| 28 | [rustc-demangle]       | [@alexcrichton] | Apache-2.0/MIT | Symbol demangling         |
-| 29 | [secrecy]              | [iqlusion]      | Apache-2.0     | Secret-keeping types      |
-| 30 | [semver]               | [@steveklabnik] | Apache-2.0/MIT | Semantic versioning       |
-| 31 | [semver-parser]        | [@steveklabnik] | Apache-2.0/MIT | Parser for semver spec    |
-| 32 | [serde]                | [serde-rs]      | Apache-2.0/MIT | Serialization framework   |
-| 33 | [sharded-slab]         | [@hawkw]        | MIT            | Concurrent slab allocator |
-| 34 | [signal-hook]          | [@vorner]       | Apache-2.0/MIT | Unix signal handling      |
-| 35 | [signal-hook-registry] | [@vorner]       | Apache-2.0/MIT | Unix signal registry      |
-| 36 | [smallvec]             | [servo]         | Apache-2.0/MIT | Optimized small vectors   |
-| 37 | [termcolor]            | [@BurntSushi]   | MIT/Unlicense  | Terminal color support    |
-| 38 | [thread_local]         | [@Amanieu]      | Apache-2.0/MIT | Per-object thread local   |
-| 39 | [time]                 | [rust-lang]     | Apache-2.0/MIT | Time/date library         |
-| 40 | [toml]                 | [@alexcrichton] | Apache-2.0/MIT | TOML parser library       |
-| 41 | [tracing]              | [tokio-rs]      | MIT            | App tracing / logging     |
-| 42 | [tracing-core]         | [tokio-rs]      | MIT            | App tracing / logging     |
-| 43 | [tracing-log]          | [tokio-rs]      | MIT            | `log` compatibility       |
-| 44 | [tracing-subscriber]   | [tokio-rs]      | MIT            | Tracing subscribers       |
-| 45 | [utf8-ranges]          | [@BurntSushi]   | MIT/Unlicense  | UTF-8 codepoint ranges    |
-| 46 | [winapi]§              | [@retep998]     | Apache-2.0/MIT | Windows FFI bindings      |
-| 47 | [winapi-util]          | [@BurntSushi]   | MIT/Unlicense  | Safe winapi wrappers      |
-| 48 | [wincolor]             | [@BurntSushi]   | MIT/Unlicense  | Windows console color     |
-| 49 | [zeroize]              | [iqlusion]      | Apache-2.0/MIT | Zero out sensitive data   |
+| #  | Crate Name             | Origin           | License        | Description               |
+|----|------------------------|------------------|----------------|---------------------------|
+| 1  | [abscissa_core]        | [iqlusion]       | Apache-2.0     | Abscissa framework        |
+| 2  | [aho-corasick]         | [@BurntSushi]    | MIT/Unlicense  | Pattern-matching alg      |
+| 3  | [ansi_term]            | [@ogham]         | MIT            | Terminal color libray     |
+| 4  | [arc-swap]             | [@vorner]        | Apache-2.0/MIT | Atomic swap for `Arc`     |
+| 5  | [atty]                 | [@softprops]     | MIT            | Detect TTY presence       |
+| 6  | [autocfg]              | [@cuviper]       | Apache-2.0/MIT | Rust compiler configs     |
+| 7  | [backtrace]            | [@alexcrichton]  | Apache-2.0/MIT | Capture stack traces      |
+| 8  | [backtrace-sys]        | [@alexcrichton]  | Apache-2.0/MIT | Capture stack traces      |
+| 9  | [byteorder]            | [@BurntSushi]    | MIT/Unlicense  | Byte order conversions    |
+| 10 | [canonical-path]       | [iqlusion]       | Apache-2.0     | Get canonical fs paths    |
+| 11 | [chrono]               | [chronotope]     | Apache-2.0/MIT | Time/date library         |
+| 12 | [color-backtrace]      | [@athre0z]       | Apache-2.0/MIT | Rich colored backtraces   |
+| 13 | [fs-err]               | [@andrewhickman] | Apache-2.0/MIT | Better filesystem errors |
+| 14 | [generational-arena]   | [@fitzgen]       | MPL-2.0        | Component allocator       |
+| 15 | [gumdrop]              | [@Murarth]       | Apache-2.0/MIT | Command-line options      |
+| 16 | [lazy_static]          | [rust-lang]      | Apache-2.0/MIT | Heap-allocated statics    |
+| 17 | [libc]                 | [rust-lang]      | Apache-2.0/MIT | C library wrapper         |
+| 18 | [log]                  | [rust-lang]      | Apache-2.0/MIT | Logging facade library    |
+| 19 | [matchers]             | [@hawkw]         | MIT            | Stream regex matching     |
+| 20 | [maybe-uninit]         | [@est31]         | Apache-2.0/MIT | MaybeUninit compat        |
+| 21 | [memchr]               | [@BurntSushi]    | MIT/Unlicense  | Optimized byte search     |
+| 22 | [num-integer]          | [rust-num]       | Apache-2.0/MIT | `Integer` trait           |
+| 23 | [num-traits]           | [rust-num]       | Apache-2.0/MIT | Numeric traits            |
+| 24 | [once_cell]            | [@matklad]       | Apache-2.0/MIT | Single assignment cells   |
+| 25 | [redox_syscall]        | [redox-os]       | MIT            | Redox OS syscall API      |
+| 26 | [regex]                | [rust-lang]      | Apache-2.0/MIT | Regular expressions       |
+| 27 | [regex-automata]       | [@BurntSushi]    | MIT/Unlicense  | Low-level regex DFAs      |
+| 28 | [regex-syntax]         | [rust-lang]      | Apache-2.0/MIT | Regex syntax impl         |
+| 29 | [rustc-demangle]       | [@alexcrichton]  | Apache-2.0/MIT | Symbol demangling         |
+| 30 | [secrecy]              | [iqlusion]       | Apache-2.0     | Secret-keeping types      |
+| 31 | [semver]               | [@steveklabnik]  | Apache-2.0/MIT | Semantic versioning       |
+| 32 | [semver-parser]        | [@steveklabnik]  | Apache-2.0/MIT | Parser for semver spec    |
+| 33 | [serde]                | [serde-rs]       | Apache-2.0/MIT | Serialization framework   |
+| 34 | [sharded-slab]         | [@hawkw]         | MIT            | Concurrent slab allocator |
+| 35 | [signal-hook]          | [@vorner]        | Apache-2.0/MIT | Unix signal handling      |
+| 36 | [signal-hook-registry] | [@vorner]        | Apache-2.0/MIT | Unix signal registry      |
+| 37 | [smallvec]             | [servo]          | Apache-2.0/MIT | Optimized small vectors   |
+| 38 | [termcolor]            | [@BurntSushi]    | MIT/Unlicense  | Terminal color support    |
+| 39 | [thread_local]         | [@Amanieu]       | Apache-2.0/MIT | Per-object thread local   |
+| 40 | [time]                 | [rust-lang]      | Apache-2.0/MIT | Time/date library         |
+| 41 | [toml]                 | [@alexcrichton]  | Apache-2.0/MIT | TOML parser library       |
+| 42 | [tracing]              | [tokio-rs]       | MIT            | App tracing / logging     |
+| 43 | [tracing-core]         | [tokio-rs]       | MIT            | App tracing / logging     |
+| 44 | [tracing-log]          | [tokio-rs]       | MIT            | `log` compatibility       |
+| 45 | [tracing-subscriber]   | [tokio-rs]       | MIT            | Tracing subscribers       |
+| 46 | [utf8-ranges]          | [@BurntSushi]    | MIT/Unlicense  | UTF-8 codepoint ranges    |
+| 47 | [winapi]§              | [@retep998]      | Apache-2.0/MIT | Windows FFI bindings      |
+| 48 | [winapi-util]          | [@BurntSushi]    | MIT/Unlicense  | Safe winapi wrappers      |
+| 49 | [wincolor]             | [@BurntSushi]    | MIT/Unlicense  | Windows console color     |
+| 50 | [zeroize]              | [iqlusion]       | Apache-2.0/MIT | Zero out sensitive data   |
 
 ### Build / Development / Testing Dependencies
 
@@ -180,74 +181,75 @@ an Abscissa dependency and whether or not it is optional. Abscissa uses
 [cargo features] to allow parts of it you aren't using to be easily disabled,
 so you only compile the parts you need.
 
-| Crate Name             | [Cargo Features]   | Required By               |
-|------------------------|--------------------|---------------------------|
-| [abscissa_core]        | -                  | ⊤                         |
-| [abscissa_derive]      | -                  | [abscissa_core]           |
-| [aho-corasick]         | `trace`, `testing` | [regex]                   |
-| [ansi_term]            | `trace`            | [tracing-subscriber]      |
-| [arc-swap]             | `signals`          | [signal-hook-registry]    |
-| [atty]                 | `terminal`         | [color-backtrace]         |
-| [autocfg]              | `time`             | [num-integer]             |
-| [backtrace]            | -                  | [abscissa_core]           |
-| [backtrace-sys]        | -                  | [backtrace]               |
-| [byteorder]            | `trace`            | [regex-automata]          |
-| [canonical-path]       | -                  | [abscissa_core]           |
-| [cc]                   | -                  | [backtrace-sys]           |
-| [cfg-if]               | -                  | [backtrace], [log]        |
-| [color-backtrace]      | `terminal`         | [abscissa_core]           |
-| [chrono]               | `time`             | [abscissa_core]           |
-| [darling]              | -                  | [abscissa_derive]         |
+| Crate Name             | [Cargo Features]   | Required By                |
+|------------------------|--------------------|----------------------------|
+| [abscissa_core]        | -                  | ⊤                          |
+| [abscissa_derive]      | -                  | [abscissa_core]            |
+| [aho-corasick]         | `trace`, `testing` | [regex]                    |
+| [ansi_term]            | `trace`            | [tracing-subscriber]       |
+| [arc-swap]             | `signals`          | [signal-hook-registry]     |
+| [atty]                 | `terminal`         | [color-backtrace]          |
+| [autocfg]              | `time`             | [num-integer]              |
+| [backtrace]            | -                  | [abscissa_core]            |
+| [backtrace-sys]        | -                  | [backtrace]                |
+| [byteorder]            | `trace`            | [regex-automata]           |
+| [canonical-path]       | -                  | [abscissa_core]            |
+| [cc]                   | -                  | [backtrace-sys]            |
+| [cfg-if]               | -                  | [backtrace], [log]         |
+| [color-backtrace]      | `terminal`         | [abscissa_core]            |
+| [chrono]               | `time`             | [abscissa_core]            |
+| [darling]              | -                  | [abscissa_derive]          |
 | [darling_core]         | -                  | [darling], [darling_macro] |
-| [darling_macro]        | -                  | [darling]                 |
-| [fnv]                  | -                  | [darling_core]            |
-| [generational-arena]   | `application`      | [abscissa_core]           |
-| [gumdrop]              | `options`          | [abscissa_core]           |
-| [gumdrop_derive]       | `options`          | [gumdrop]                 |
+| [darling_macro]        | -                  | [darling]                  |
+| [fs-err]               | -                  | [abscissa_core]            |
+| [fnv]                  | -                  | [darling_core]             |
+| [generational-arena]   | `application`      | [abscissa_core]            |
+| [gumdrop]              | `options`          | [abscissa_core]            |
+| [gumdrop_derive]       | `options`          | [gumdrop]                  |
 | [ident_case]           | -                  | [abscissa_derive], [darling_core] |
 | [lazy_static]          | `testing`, `trace` | [thread_local], [tracing-core], [tracing-log], [tracing-subscriber] |
-| [libc]                 | `signals`          | [abscissa_core]           |
-| [log]                  | `logging`          | [abscissa_core]           |
-| [matchers]             | `trace`            | [tracing-subscriber]      |
-| [memchr]               | `trace`, `testing` | [aho-corasick]            |
-| [maybe-uninit]         | `trace`            | [smallvec]                |
-| [num-integer]          | `time`             | [chrono]                  |
-| [num-traits]           | `time`             | [chrono], [num-integer]   |
-| [once_cell]            | -                  | [abscissa_core]           |
+| [libc]                 | `signals`          | [abscissa_core]            |
+| [log]                  | `logging`          | [abscissa_core]            |
+| [matchers]             | `trace`            | [tracing-subscriber]       |
+| [memchr]               | `trace`, `testing` | [aho-corasick]             |
+| [maybe-uninit]         | `trace`            | [smallvec]                 |
+| [num-integer]          | `time`             | [chrono]                   |
+| [num-traits]           | `time`             | [chrono], [num-integer]    |
+| [once_cell]            | -                  | [abscissa_core]            |
 | [proc-macro2]          | -                  | [abscissa_derive], [darling], [quote], [serde_derive], [syn] |
 | [quote]                | -                  | [abscissa_derive], [darling], [gumdrop_derive], [serde_derive] |
-| [redox_syscall]        | `time`             | [time]                    |
-| [regex]                | `trace`, `testing` | [abscissa_core]           |
-| [regex-automata]       | `trace`            | [matchers]                |
-| [regex-syntax]         | `trace`, `testing` | [abscissa_core]           |
-| [rustc-demangle]       | -                  | [backtrace]               |
-| [secrecy]              | `secrets`          | [abscissa_core]           |
-| [semver]               | `application`      | [abscissa_core]           |
-| [semver-parser]        | `application`      | [abscissa_core]           |
-| [serde]                | `config`           | [abscissa_core]           |
-| [serde_derive]         | `config`           | [serde]                   |
-| [signal-hook]          | `signals`          | [abscissa_core]           |
-| [sharded-slab]         | `trace`            | [tracing-subscriber]      |
-| [signal-hook-registry] | `signals`          | [signal-hook]             |
-| [smallvec]             | `trace`            | [tracing-subscriber]      |
-| [strsim]               | -                  | [darling_core]            |
+| [redox_syscall]        | `time`             | [time]                     |
+| [regex]                | `trace`, `testing` | [abscissa_core]            |
+| [regex-automata]       | `trace`            | [matchers]                 |
+| [regex-syntax]         | `trace`, `testing` | [abscissa_core]            |
+| [rustc-demangle]       | -                  | [backtrace]                |
+| [secrecy]              | `secrets`          | [abscissa_core]            |
+| [semver]               | `application`      | [abscissa_core]            |
+| [semver-parser]        | `application`      | [abscissa_core]            |
+| [serde]                | `config`           | [abscissa_core]            |
+| [serde_derive]         | `config`           | [serde]                    |
+| [signal-hook]          | `signals`          | [abscissa_core]            |
+| [sharded-slab]         | `trace`            | [tracing-subscriber]       |
+| [signal-hook-registry] | `signals`          | [signal-hook]              |
+| [smallvec]             | `trace`            | [tracing-subscriber]       |
+| [strsim]               | -                  | [darling_core]             |
 | [syn]                  | -                  | [abscissa_derive], [darling], [gumdrop_derive], [serde_derive] |
-| [termcolor]            | `terminal`         | [abscissa_core]           |
-| [thiserror]            | -                  | Abscissa boilerplate      |
-| [thread_local]         | `trace`, `testing` | [regex]                   |
-| [time]                 | `logging`          | [chrono]                  |
-| [tracing]              | `trace`            | [abscissa_core]           |
-| [tracing-attributes]   | `trace`            | [tracing]                 |
-| [tracing-core]         | `trace`            | [tracing]                 |
-| [tracing-log]          | `trace`            | [abscissa_core]           |
-| [tracing-subscriber]   | `trace`            | [abscissa_core]           |
-| [unicode-xid]          | -                  | [proc-macro2], [syn]      |
-| [utf8-ranges]          | `trace`, `testing` | [regex]                   |
-| [wait-timeout]         | `testing`          | [abscissa_core]           |
+| [termcolor]            | `terminal`         | [abscissa_core]            |
+| [thiserror]            | -                  | Abscissa boilerplate       |
+| [thread_local]         | `trace`, `testing` | [regex]                    |
+| [time]                 | `logging`          | [chrono]                   |
+| [tracing]              | `trace`            | [abscissa_core]            |
+| [tracing-attributes]   | `trace`            | [tracing]                  |
+| [tracing-core]         | `trace`            | [tracing]                  |
+| [tracing-log]          | `trace`            | [abscissa_core]            |
+| [tracing-subscriber]   | `trace`            | [abscissa_core]            |
+| [unicode-xid]          | -                  | [proc-macro2], [syn]       |
+| [utf8-ranges]          | `trace`, `testing` | [regex]                    |
+| [wait-timeout]         | `testing`          | [abscissa_core]            |
 | [winapi]§              | -                  | [termcolor], [time], [winapi-util] |
-| [winapi-util]          | -                  | [termcolor]               |
-| [wincolor]             | `terminal`         | [termcolor]               |
-| [zeroize]              | -                  | [abscissa_core]           |
+| [winapi-util]          | -                  | [termcolor]                |
+| [wincolor]             | `terminal`         | [termcolor]                |
+| [zeroize]              | -                  | [abscissa_core]            |
 
 * § `winapi` is a facade for either [winapi-i686-pc-windows-gnu] or
     [winapi-x86_64-pc-windows-gnu] which aren't explicitly listed for brevity
@@ -396,6 +398,7 @@ read the [CONTRIBUTING.md] and [CODE_OF_CONDUCT.md] files first.
 [darling]: https://crates.io/crates/darling
 [darling_core]: https://crates.io/crates/darling_core
 [darling_macro]: https://crates.io/crates/darling_macro
+[fs-err]: https://crates.io/crates/fs-err
 [fnv]: https://crates.io/crates/fnv
 [generational-arena]: https://github.com/fitzgen/generational-arena
 [gumdrop]: https://crates.io/crates/gumdrop
@@ -453,6 +456,7 @@ read the [CONTRIBUTING.md] and [CODE_OF_CONDUCT.md] files first.
 
 [@alexcrichton]: https://github.com/alexcrichton
 [@Amanieu]: https://github.com/Amanieu
+[@andrewhickman]: https://github.com/andrewhickman
 [@athre0z]: https://github.com/athre0z
 [@BurntSushi]: https://github.com/BurntSushi
 [@cuviper]: https://github.com/cuviper

--- a/cli/src/commands/gen/cmd.rs
+++ b/cli/src/commands/gen/cmd.rs
@@ -1,11 +1,10 @@
 //! Generate a new subcommand in an existing application
 
 use crate::{config::target_app_root, error::Error, handlebars_registry, prelude::*};
-use abscissa_core::{Command, Options, Runnable};
+use abscissa_core::{fs, Command, Options, Runnable};
 use ident_case::RenameRule;
 use serde::Serialize;
 use std::{
-    fs,
     path::{Path, PathBuf},
     process::exit,
 };

--- a/cli/src/commands/new.rs
+++ b/cli/src/commands/new.rs
@@ -8,10 +8,13 @@ use crate::{
     properties::{self, Properties},
     template::{Collection, Template},
 };
-use abscissa_core::{status_err, status_info, status_ok, status_warn, Command, Options, Runnable};
+use abscissa_core::{
+    fs::{self, File},
+    status_err, status_info, status_ok, status_warn, Command, Options, Runnable,
+};
 use ident_case::RenameRule;
 use std::{
-    fs, io,
+    io,
     path::{Path, PathBuf},
     process,
     time::Instant,
@@ -154,7 +157,7 @@ impl NewCommand {
             )
         })?;
 
-        let mut output_file = fs::File::create(&output_path).map_err(|e| {
+        let mut output_file = File::create(&output_path).map_err(|e| {
             format_err!(
                 ErrorKind::Path,
                 "couldn't create {}: {}",

--- a/cli/tests/generate_app.rs
+++ b/cli/tests/generate_app.rs
@@ -4,9 +4,9 @@
 #![deny(warnings, missing_docs, unused_import_braces, unused_qualifications)]
 #![forbid(unsafe_code)]
 
-use abscissa_core::testing::prelude::*;
+use abscissa_core::{fs, testing::prelude::*};
 use once_cell::sync::Lazy;
-use std::{env, fs, path::Path};
+use std::{env, path::Path};
 
 /// Name of our test application
 const APP_NAME: &str = "abscissa_gen_test_app";

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -24,6 +24,7 @@ backtrace = "0.3"
 canonical-path = "2"
 chrono = { version = "0.4", optional = true, features = ["serde"] }
 color-backtrace = { version = "0.4", optional = true, default-features = false }
+fs-err = "2"
 generational-arena = { version = "0.2", optional = true }
 gumdrop = { version = "0.7", optional = true }
 once_cell = "1.4"

--- a/core/src/config.rs
+++ b/core/src/config.rs
@@ -7,12 +7,13 @@ mod reader;
 pub use self::{configurable::Configurable, overrides::Override, reader::Reader};
 
 use crate::{
+    fs::File,
     path::AbsPath,
     FrameworkError,
     FrameworkErrorKind::{ConfigError, IoError, PathError},
 };
 use serde::de::DeserializeOwned;
-use std::{fmt::Debug, fs::File, io::Read};
+use std::{fmt::Debug, io::Read};
 
 /// Trait for Abscissa configuration data structures
 pub trait Config: Debug + Default + DeserializeOwned {
@@ -33,7 +34,7 @@ where
     }
 
     fn load_toml_file(path: impl AsRef<AbsPath>) -> Result<Self, FrameworkError> {
-        let mut file = File::open(path.as_ref()).map_err(|e| {
+        let mut file = File::open(path.as_ref().as_path()).map_err(|e| {
             let io_error = IoError.context(e);
             let path_error = PathError {
                 name: Some(path.as_ref().as_path().into()),

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -164,6 +164,7 @@ pub use crate::{
 
 #[cfg(feature = "time")]
 pub use chrono as time;
+pub use fs_err as fs;
 #[cfg(feature = "secrets")]
 pub use secrecy as secret;
 #[cfg(feature = "secrets")]

--- a/core/src/testing/config.rs
+++ b/core/src/testing/config.rs
@@ -1,11 +1,13 @@
 //! Support for writing config files and using them in tests
 
-use crate::time::Utc;
+use crate::{
+    fs::{self, File, OpenOptions},
+    time::Utc,
+};
 use serde::Serialize;
 use std::{
     env,
     ffi::OsStr,
-    fs::{self, File, OpenOptions},
     io::{self, Write},
     path::{Path, PathBuf},
 };


### PR DESCRIPTION
The `fs_err` crate is a drop-in replacement for `std:::fs` with zero transitive dependencies which provides error messages that include the filename in addition to the failing operation:

https://github.com/andrewhickman/fs-err

This commit re-exports it as `abscissa_core::fs` and uses it to implement all framework-level filesystem operations.

## Example

```rust
let file = File::open("does not exist.txt")?;
```

### `std::fs::File` error message

```
The system cannot find the file specified. (os error 2)
```

### `fs_err::File` error message

```
failed to open file `does not exist.txt`
    caused by: The system cannot find the file specified. (os error 2)
```

cc @yaahc