### PR TITLE
don't end status messages with trailing spaces if msg is empty

### DIFF
--- a/core/src/terminal/status.rs
+++ b/core/src/terminal/status.rs
@@ -263,7 +263,10 @@ impl Status {
         }
 
         s.reset()?;
-        writeln!(s, " {}", msg.as_ref())?;
+        let msg = msg.as_ref();
+        if !msg.is_empty() {
+            writeln!(s, " {}", msg)?;
+        }
         s.flush()?;
 
         Ok(())


### PR DESCRIPTION
fixes https://github.com/RustSec/cargo-audit/issues/293