### PR TITLE
core: remove `gimli-backtrace` feature

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -62,10 +62,6 @@ config = [
     "terminal",
     "toml"
 ]
-gimli-backtrace = [
-    "backtrace/gimli-symbolize",
-    "color-backtrace/gimli-symbolize"
-]
 trace = ["tracing", "tracing-log", "tracing-subscriber"]
 options = ["gumdrop"]
 secrets = ["secrecy"]


### PR DESCRIPTION
Gimli has been enabled by-default in the `backtrace` crate for awhile, so the `gimli-backtrace` feature no longer serves any purpose.