### PR TITLE
core: replace `color-backtrace` with `color-eyre`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -22,7 +22,7 @@ dependencies = [
  "backtrace",
  "canonical-path",
  "chrono",
- "color-backtrace",
+ "color-eyre",
  "fs-err",
  "gumdrop",
  "once_cell",
@@ -96,17 +96,6 @@ name = "arc-swap"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec5a4539a733493f412c4d0bb962748ea1f90f3dfdba9ff3ee18acbefc3b33f0"
-
-[[package]]
-name = "atty"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
-dependencies = [
- "hermit-abi",
- "libc",
- "winapi",
-]
 
 [[package]]
 name = "autocfg"
@@ -200,14 +189,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "color-backtrace"
-version = "0.5.0"
+name = "color-eyre"
+version = "0.5.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54d692cadb16939b888c8232945dec39372207dd6893d19f536e318d14dc1468"
+checksum = "7b29030875fd8376e4a28ef497790d5b4a7843d8d1396bf08ce46f5eec562c5c"
 dependencies = [
- "atty",
  "backtrace",
- "termcolor",
+ "eyre",
+ "indenter",
+ "once_cell",
+ "owo-colors",
 ]
 
 [[package]]
@@ -252,6 +243,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3d0c8c8752312f9713efd397ff63acb9f85585afbf179282e720e7704954dd5"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "eyre"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f29abf4740a4778632fe27a4f681ef5b7a6f659aeba3330ac66f48e20cfa3b7"
+dependencies = [
+ "indenter",
+ "once_cell",
 ]
 
 [[package]]
@@ -348,6 +349,12 @@ name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
+name = "indenter"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68b772bb6a163b53b7e02b2d4735e0b399df6fc68e74374dbea85cd22a36e9db"
 
 [[package]]
 name = "itoa"
@@ -466,6 +473,12 @@ name = "opaque-debug"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2839e79665f131bdb5782e51f2c6c9599c133c6098982a54c794358bf432529c"
+
+[[package]]
+name = "owo-colors"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13370dae44474229701bb69b90b4f4dca6404cb0357a2d50d635f1171dc3aa7b"
 
 [[package]]
 name = "pest"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -21,7 +21,7 @@ arc-swap = { version = "1", optional = true }
 backtrace = "0.3"
 canonical-path = "2"
 chrono = { version = "0.4", optional = true, features = ["serde"] }
-color-backtrace = { version = "0.5", optional = true, default-features = false }
+color-eyre = { version = "0.5", optional = true, default-features = false }
 fs-err = "2"
 gumdrop = { version = "0.7", optional = true }
 once_cell = "1.4"
@@ -65,6 +65,6 @@ config = [
 trace = ["tracing", "tracing-log", "tracing-subscriber"]
 options = ["gumdrop"]
 secrets = ["secrecy"]
-terminal = ["color-backtrace", "termcolor"]
+terminal = ["color-eyre", "termcolor"]
 testing = ["regex", "wait-timeout"]
 time = ["chrono"]

--- a/core/src/terminal/component.rs
+++ b/core/src/terminal/component.rs
@@ -1,30 +1,24 @@
 //! Terminal component
 
 use crate::Component;
-use std::fmt;
 use termcolor::ColorChoice;
 
 /// Abscissa terminal subsystem component
-#[derive(Component)]
+#[derive(Component, Debug)]
 #[component(core)]
 pub struct Terminal {}
 
 impl Terminal {
-    /// Create a new `TerminalComponent` with the given `ColorChoice`
+    /// Create a new [`Terminal`] component with the given [`ColorChoice`]
     pub fn new(color_choice: ColorChoice) -> Terminal {
         // TODO(tarcieri): handle terminal reinit (without panicking)
         super::init(color_choice);
 
         if color_choice != ColorChoice::Never {
-            color_backtrace::install();
+            // TODO(tarcieri): avoid panicking here
+            color_eyre::install().expect("couldn't install color-eyre");
         }
 
         Self {}
-    }
-}
-
-impl fmt::Debug for Terminal {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "TerminalComponent {{ stdout, stderr }}")
     }
 }


### PR DESCRIPTION
This begins a general migration to `eyre` for error handling:

https://github.com/yaahc/color-eyre