### PR TITLE
Bump MSRV to 1.51+

### DIFF
--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -22,7 +22,7 @@ jobs:
           - macos-latest
           - windows-latest
         rust:
-          - 1.45.0 # MSRV
+          - 1.51.0 # MSRV
           - stable
     runs-on: ${{ matrix.platform }}
     steps:

--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -26,7 +26,7 @@ jobs:
           - macos-latest
           - windows-latest
         rust:
-          - 1.45.0 # MSRV
+          - 1.51.0 # MSRV
           - stable
     runs-on: ${{ matrix.platform }}
     steps:
@@ -47,7 +47,7 @@ jobs:
           - macos-latest
           - windows-latest
         rust:
-          - 1.45.0 # MSRV
+          - 1.51.0 # MSRV
           - stable
     runs-on: ${{ matrix.platform }}
     steps:

--- a/.github/workflows/derive.yml
+++ b/.github/workflows/derive.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.45.0 # MSRV
+          - 1.51.0 # MSRV
           - stable
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/tokio.yml
+++ b/.github/workflows/tokio.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.45.0 # MSRV
+          - 1.51.0 # MSRV
           - stable
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/workspace.yml
+++ b/.github/workflows/workspace.yml
@@ -16,7 +16,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions-rs/toolchain@v1
       with:
-        toolchain: 1.45.0 # MSRV
+        toolchain: 1.51.0 # MSRV
         components: clippy
         override: true
         profile: minimal

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,2 +1,3 @@
 [workspace]
 members = ["core", "cli", "derive", "tokio"]
+resolver = "2"

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Abscissa presently consists of three crates:
 
 ## Minimum Supported Rust Version
 
-- Rust **1.45+**
+Requires Rust **1.51** or newer.
 
 ## Installation
 

--- a/tokio/src/lib.rs
+++ b/tokio/src/lib.rs
@@ -16,9 +16,9 @@
 //!
 //! # Requirements
 //!
-//! - Rust 1.45+
-//! - Abscissa 0.5
-//! - Tokio 0.2
+//! - Rust 1.51 or newer
+//! - Abscissa 0.6
+//! - Tokio 1.x
 //!
 //! # Usage
 //!


### PR DESCRIPTION
This is needed to make progress on #540, and also lets us switch to the V2 Cargo resolver.