### PR TITLE
v0.6.0-pre.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5,7 +5,7 @@ version = 3
 
 [[package]]
 name = "abscissa"
-version = "0.6.0-pre.1"
+version = "0.6.0-pre.2"
 dependencies = [
  "abscissa_core",
  "clap",
@@ -17,7 +17,7 @@ dependencies = [
 
 [[package]]
 name = "abscissa_core"
-version = "0.6.0-pre.1"
+version = "0.6.0-pre.2"
 dependencies = [
  "abscissa_derive",
  "arc-swap",
@@ -42,7 +42,7 @@ dependencies = [
 
 [[package]]
 name = "abscissa_derive"
-version = "0.6.0-pre.1"
+version = "0.6.0-pre.2"
 dependencies = [
  "darling",
  "ident_case",
@@ -54,7 +54,7 @@ dependencies = [
 
 [[package]]
 name = "abscissa_tokio"
-version = "0.6.0-pre.2"
+version = "0.6.0-pre.3"
 dependencies = [
  "abscissa_core",
  "actix-rt",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -5,7 +5,7 @@ Application microframework with support for command-line option parsing,
 configuration, error handling, logging, and terminal interactions.
 This crate contains a CLI utility for generating new applications.
 """
-version    = "0.6.0-pre.1" # Also update html_root_url in lib.rs when bumping this
+version    = "0.6.0-pre.2" # Also update html_root_url in lib.rs when bumping this
 license    = "Apache-2.0"
 authors    = ["Tony Arcieri <tony@iqlusion.io>"]
 edition    = "2018"
@@ -16,19 +16,12 @@ categories = ["command-line-interface", "config", "rust-patterns"]
 keywords   = ["abscissa", "cli", "application", "framework", "service"]
 
 [dependencies]
+abscissa_core = { version = "=0.6.0-pre.2", path = "../core" }
 clap = "3.0.0-beta.4"
 handlebars = "4"
 ident_case = "1"
 serde = { version = "1", features = ["serde_derive"] }
 
-[dependencies.abscissa_core]
-version = "=0.6.0-pre.1"
-path = "../core"
-
 [dev-dependencies]
+abscissa_core = { version = "=0.6.0-pre.2", features = ["testing"], path = "../core" }
 once_cell = "1.4"
-
-[dev-dependencies.abscissa_core]
-version = "=0.6.0-pre.1"
-features = ["testing"]
-path = "../core"

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -6,7 +6,7 @@
 
 #![doc(
     html_logo_url = "https://www.iqlusion.io/img/github/iqlusioninc/abscissa/abscissa-sq.svg",
-    html_root_url = "https://docs.rs/abscissa_core/0.5.1"
+    html_root_url = "https://docs.rs/abscissa_core/0.6.0-pre.2"
 )]
 #![forbid(unsafe_code)]
 #![warn(rust_2018_idioms, unused_lifetimes, unused_qualifications)]

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -5,7 +5,7 @@ Application microframework with support for command-line option parsing,
 configuration, error handling, logging, and terminal interactions.
 This crate contains the framework's core functionality.
 """
-version    = "0.6.0-pre.1" # Also update html_root_url in lib.rs when bumping this
+version    = "0.6.0-pre.2" # Also update html_root_url in lib.rs when bumping this
 license    = "Apache-2.0"
 authors    = ["Tony Arcieri <tony@iqlusion.io>"]
 edition    = "2018"
@@ -16,7 +16,7 @@ categories = ["command-line-interface", "config", "rust-patterns"]
 keywords   = ["abscissa", "cli", "application", "framework", "service"]
 
 [dependencies]
-abscissa_derive = { version = "=0.6.0-pre.1", path = "../derive" }
+abscissa_derive = { version = "=0.6.0-pre.2", path = "../derive" }
 arc-swap = { version = "1", optional = true }
 backtrace = "0.3"
 canonical-path = "2"

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -87,7 +87,7 @@
 
 #![doc(
     html_logo_url = "https://www.iqlusion.io/img/github/iqlusioninc/abscissa/abscissa-sq.svg",
-    html_root_url = "https://docs.rs/abscissa_core/0.5.2"
+    html_root_url = "https://docs.rs/abscissa_core/0.6.0-pre.2"
 )]
 #![forbid(unsafe_code)]
 #![warn(

--- a/derive/Cargo.toml
+++ b/derive/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name        = "abscissa_derive"
 description = "Custom derive support for the abscissa application microframework"
-version     = "0.6.0-pre.1" # Also update html_root_url in lib.rs when bumping this
+version     = "0.6.0-pre.2" # Also update html_root_url in lib.rs when bumping this
 license     = "Apache-2.0"
 authors     = ["Tony Arcieri <tony@iqlusion.io>"]
 edition     = "2018"

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -3,7 +3,7 @@
 #![crate_type = "proc-macro"]
 #![doc(
     html_logo_url = "https://www.iqlusion.io/img/github/iqlusioninc/abscissa/abscissa-sq.svg",
-    html_root_url = "https://docs.rs/abscissa_derive/0.5.0"
+    html_root_url = "https://docs.rs/abscissa_derive/0.6.0-pre.2"
 )]
 #![forbid(unsafe_code)]
 #![warn(rust_2018_idioms, unused_lifetimes, unused_qualifications)]

--- a/tokio/Cargo.toml
+++ b/tokio/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name        = "abscissa_tokio"
 description = "Support for launching Tokio runtimes within Abscissa applications"
-version     = "0.6.0-pre.2" # Also update html_root_url in lib.rs when bumping this
+version     = "0.6.0-pre.3" # Also update html_root_url in lib.rs when bumping this
 license     = "Apache-2.0"
 authors     = ["Tony Arcieri <tony@iqlusion.io>"]
 edition     = "2018"
@@ -10,7 +10,7 @@ repository  = "https://github.com/iqlusioninc/abscissa/tree/main/tokio"
 readme      = "README.md"
 
 [dependencies]
-abscissa_core = { version = "=0.6.0-pre.1", path = "../core" }
+abscissa_core = { version = "0.6.0-pre.2", path = "../core" }
 tokio = { version = "1", features = ["rt-multi-thread"] }
 actix-rt = { version = "2.2", optional = true }
 

--- a/tokio/src/lib.rs
+++ b/tokio/src/lib.rs
@@ -89,7 +89,7 @@
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![doc(
     html_logo_url = "https://www.iqlusion.io/img/github/iqlusioninc/abscissa/abscissa-sq.svg",
-    html_root_url = "https://docs.rs/abscissa_tokio/0.6.0-pre.2"
+    html_root_url = "https://docs.rs/abscissa_tokio/0.6.0-pre.3"
 )]
 #![forbid(unsafe_code)]
 #![warn(rust_2018_idioms, unused_lifetimes, unused_qualifications)]


### PR DESCRIPTION
Includes migration to `clap` v3 for command-line argument parsing (#562)