### PR TITLE
Remove `chrono` dependency

### DIFF
--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -14,11 +14,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Cache cargo bin
-        uses: actions/cache@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+          profile: minimal
+      - uses: actions/cache@v1
         with:
           path: ~/.cargo/bin
-          key: ${{ runner.os }}-cargo-audit-v0.13.1
+          key: ${{ runner.os }}-cargo-audit-v0.15.2
       - uses: actions-rs/audit-check@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -23,7 +23,6 @@ dependencies = [
  "arc-swap",
  "backtrace",
  "canonical-path",
- "chrono",
  "clap",
  "clap_derive",
  "color-eyre",
@@ -210,20 +209,6 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
-
-[[package]]
-name = "chrono"
-version = "0.4.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "670ad68c9088c2a963aaa298cb369688cf3f9465ce5e2d4ca10e6e0098a1ce73"
-dependencies = [
- "libc",
- "num-integer",
- "num-traits",
- "serde",
- "time",
- "winapi",
-]
 
 [[package]]
 name = "clap"
@@ -527,25 +512,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f6bb902e437b6d86e03cce10a7e2af662292c5dfef23b65899ea3ac9354ad44"
 dependencies = [
  "winapi",
-]
-
-[[package]]
-name = "num-integer"
-version = "0.1.44"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2cc698a63b549a70bc047073d2949cce27cd1c7b0a4a862d08a8031bc2801db"
-dependencies = [
- "autocfg",
- "num-traits",
-]
-
-[[package]]
-name = "num-traits"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a64b1ec5cda2586e284722486d802acf1f7dbdc623e2bfc57e65ca1cd099290"
-dependencies = [
- "autocfg",
 ]
 
 [[package]]
@@ -912,17 +878,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "time"
-version = "0.1.44"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db9e6914ab8b1ae1c260a4ae7a49b6c5611b40328a735b21862567685e73255"
-dependencies = [
- "libc",
- "wasi",
- "winapi",
-]
-
-[[package]]
 name = "tokio"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1062,12 +1017,6 @@ checksum = "9f200f5b12eb75f8c1ed65abd4b2db8a6e1b138a20de009dacee265a2498f3f6"
 dependencies = [
  "libc",
 ]
-
-[[package]]
-name = "wasi"
-version = "0.10.0+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
 
 [[package]]
 name = "winapi"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -21,7 +21,6 @@ abscissa_derive = { version = "=0.6.0-pre.2", path = "../derive" }
 arc-swap = { version = "1", optional = true }
 backtrace = "0.3"
 canonical-path = "2"
-chrono = { version = "0.4", optional = true, features = ["serde"] }
 color-eyre = { version = "0.5", optional = true, default-features = false }
 fs-err = "2"
 clap = { version = "=3.0.0-beta.5", optional = true }
@@ -48,7 +47,6 @@ default = [
     "application",
     "secrets",
     "testing",
-    "time"
 ]
 application = [
     "arc-swap",
@@ -64,9 +62,12 @@ config = [
     "terminal",
     "toml"
 ]
-trace = ["tracing", "tracing-log", "tracing-subscriber"]
 options = ["clap"]
 secrets = ["secrecy"]
 terminal = ["color-eyre", "termcolor"]
 testing = ["regex", "wait-timeout"]
-time = ["chrono"]
+trace = [
+    "tracing",
+    "tracing-log",
+    "tracing-subscriber"
+]

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -163,8 +163,6 @@ pub use crate::{command::Command, path::StandardPaths};
 
 // Re-exported modules/types from third-party crates
 
-#[cfg(feature = "time")]
-pub use chrono as time;
 pub use fs_err as fs;
 #[cfg(feature = "secrets")]
 pub use secrecy as secret;

--- a/core/src/testing/config.rs
+++ b/core/src/testing/config.rs
@@ -1,9 +1,6 @@
 //! Support for writing config files and using them in tests
 
-use crate::{
-    fs::{self, File, OpenOptions},
-    time::Utc,
-};
+use crate::fs::{self, File, OpenOptions};
 use serde::Serialize;
 use std::{
     env,
@@ -48,16 +45,10 @@ impl ConfigFile {
     /// Create a temporary filename for the config
     fn open(app_name: &OsStr) -> (PathBuf, File) {
         // TODO: fully `OsString`-based path building
-        let filename_prefix = app_name.to_string_lossy().to_string()
-            + &Utc::now().format("-%Y-%m-%d-%H%M%S").to_string();
+        let filename_prefix = app_name.to_string_lossy().to_string();
 
         for n in 0..FILE_CREATE_ATTEMPTS {
-            let filename = if n == 0 {
-                format!("{}.toml", &filename_prefix)
-            } else {
-                format!("{}-{}.toml", &filename_prefix, n)
-            };
-
+            let filename = format!("{}-{}.toml", &filename_prefix, n);
             let path = env::temp_dir().join(filename);
 
             match OpenOptions::new().write(true).create_new(true).open(&path) {


### PR DESCRIPTION
Abscissa isn't really using it, and while the idea of supplying some built-in date/time functionality is nice, in practice it seems to be triggering [`RUSTSEC-2020-0159`](https://rustsec.org/advisories/RUSTSEC-2020-0159) in apps that otherwise don't need it.