### PR TITLE
Update to `clap` v3.0 release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -24,7 +24,6 @@ dependencies = [
  "backtrace",
  "canonical-path",
  "clap",
- "clap_derive",
  "color-eyre",
  "fs-err",
  "once_cell",
@@ -212,9 +211,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
-version = "3.0.0-beta.5"
+version = "3.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "feff3878564edb93745d58cf63e17b63f24142506e7a20c87a5521ed7bfb1d63"
+checksum = "b1121e32687f7f90b905d4775273305baa4f32cd418923e9b0fa726533221857"
 dependencies = [
  "atty",
  "bitflags",
@@ -225,14 +224,13 @@ dependencies = [
  "strsim",
  "termcolor",
  "textwrap",
- "unicase",
 ]
 
 [[package]]
 name = "clap_derive"
-version = "3.0.0-beta.5"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b15c6b4f786ffb6192ffe65a36855bc1fc2444bcd0945ae16748dcd6ed7d0d3"
+checksum = "e1b9752c030a14235a0bd5ef3ad60a1dcac8468c30921327fc8af36b20c790b9"
 dependencies = [
  "heck",
  "proc-macro-error",
@@ -547,9 +545,9 @@ checksum = "2839e79665f131bdb5782e51f2c6c9599c133c6098982a54c794358bf432529c"
 
 [[package]]
 name = "os_str_bytes"
-version = "4.2.0"
+version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "addaa943333a514159c80c97ff4a93306530d965d27e139188283cd13e06a799"
+checksum = "8e22443d1643a904602595ba1cd8f7d896afe56d26712531c5ff73a15b2fbf64"
 dependencies = [
  "memchr",
 ]
@@ -864,9 +862,6 @@ name = "textwrap"
 version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0066c8d12af8b5acd21e00547c3797fde4e8677254a7ee429176ccebbe93dd80"
-dependencies = [
- "unicode-width",
-]
 
 [[package]]
 name = "thread_local"
@@ -977,25 +972,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56dee185309b50d1f11bfedef0fe6d036842e3fb77413abef29f8f8d1c5d4c1c"
 
 [[package]]
-name = "unicase"
-version = "2.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50f37be617794602aabbeee0be4f259dc1778fabe05e2d67ee8f79326d5cb4f6"
-dependencies = [
- "version_check",
-]
-
-[[package]]
 name = "unicode-segmentation"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8895849a949e7845e06bd6dc1aa51731a103c42707010a5b591c0038fb73385b"
-
-[[package]]
-name = "unicode-width"
-version = "0.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ed742d4ea2bd1176e236172c8429aaf54486e7ac098db29ffe6529e0ce50973"
 
 [[package]]
 name = "unicode-xid"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -18,7 +18,7 @@ rust-version = "1.56"
 
 [dependencies]
 abscissa_core = { version = "=0.6.0-beta.1", path = "../core" }
-clap = "=3.0.0-beta.5"
+clap = "3"
 handlebars = "4"
 ident_case = "1"
 serde = { version = "1", features = ["serde_derive"] }

--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -5,10 +5,10 @@ pub mod new;
 
 use self::{gen::GenCommand, new::NewCommand};
 use super::config::CliConfig;
-use abscissa_core::{Clap, Command, Configurable, Runnable};
+use abscissa_core::{clap::Parser, Command, Configurable, Runnable};
 use std::path::PathBuf;
 
-#[derive(Debug, Clap, Runnable)]
+#[derive(Debug, Parser, Runnable)]
 enum SubCommands {
     /// generate a new module in an existing app
     Gen(GenCommand),
@@ -18,7 +18,7 @@ enum SubCommands {
 }
 
 /// Abscissa CLI Subcommands
-#[derive(Command, Debug, Clap)]
+#[derive(Command, Debug, Parser)]
 #[clap(author, about, version)]
 pub struct CliCommand {
     #[clap(subcommand)]

--- a/cli/src/commands/gen.rs
+++ b/cli/src/commands/gen.rs
@@ -4,15 +4,15 @@ mod cmd;
 
 pub use cmd::Cmd;
 
-use abscissa_core::{Clap, Command, Runnable};
+use abscissa_core::{clap::Parser, Command, Runnable};
 
-#[derive(Debug, Clap, Runnable)]
+#[derive(Debug, Parser, Runnable)]
 enum SubCommands {
     Cmd(Cmd),
 }
 
 /// `gen` subcommand: code generator functionality
-#[derive(Command, Debug, Clap, Runnable)]
+#[derive(Command, Debug, Parser, Runnable)]
 pub struct GenCommand {
     /// Generate a new subcommand
     #[clap(subcommand)]

--- a/cli/src/commands/gen/cmd.rs
+++ b/cli/src/commands/gen/cmd.rs
@@ -1,7 +1,7 @@
 //! Generate a new subcommand in an existing application
 
 use crate::{config::target_app_root, error::Error, handlebars_registry, prelude::*};
-use abscissa_core::{fs, Clap, Command, Runnable};
+use abscissa_core::{clap::Parser, fs, Command, Runnable};
 use ident_case::RenameRule;
 use serde::Serialize;
 use std::{
@@ -13,7 +13,7 @@ use std::{
 const SUBCOMMAND_TEMPLATE: &str = include_str!("../../../template/src/commands/subcommand.rs.hbs");
 
 /// Generate a new subcommand in an existing application
-#[derive(Command, Debug, Clap)]
+#[derive(Command, Debug, Parser)]
 pub struct Cmd {
     /// Path to the application's `Cargo.toml`
     #[clap(long, short)]

--- a/cli/src/commands/new.rs
+++ b/cli/src/commands/new.rs
@@ -9,8 +9,9 @@ use crate::{
     template::{Collection, Template},
 };
 use abscissa_core::{
+    clap::Parser,
     fs::{self, File},
-    status_err, status_info, status_ok, status_warn, Clap, Command, Runnable,
+    status_err, status_info, status_ok, status_warn, Command, Runnable,
 };
 use ident_case::RenameRule;
 use std::{
@@ -21,7 +22,7 @@ use std::{
 };
 
 /// `new` subcommand - generate a new Abscissa application
-#[derive(Command, Debug, Default, Clap)]
+#[derive(Command, Debug, Default, Parser)]
 pub struct NewCommand {
     /// Path to the newly generated application
     app_path: Option<PathBuf>,

--- a/cli/template/Cargo.toml.hbs
+++ b/cli/template/Cargo.toml.hbs
@@ -5,7 +5,7 @@ version = "{{version}}"
 edition = "{{edition}}"
 
 [dependencies]
-clap = "3.0.0-beta.5"
+clap = "3"
 serde = { version = "1", features = ["serde_derive"] }
 thiserror = "1"
 

--- a/cli/template/src/commands.rs.hbs
+++ b/cli/template/src/commands.rs.hbs
@@ -14,7 +14,8 @@ mod start;
 
 use self::start::StartCmd;
 use crate::config::{{~config_type~}};
-use abscissa_core::{config::Override, Clap, Command, Configurable, FrameworkError, Runnable};
+use abscissa_core::{config::Override, Command, Configurable, FrameworkError, Runnable};
+use clap::Parser;
 use std::path::PathBuf;
 
 /// {{title}} Configuration Filename
@@ -22,14 +23,14 @@ pub const CONFIG_FILE: &str = "{{name}}.toml";
 
 /// {{title}} Subcommands
 /// Subcommands need to be listed in an enum.
-#[derive(Command, Debug, Clap, Runnable)]
+#[derive(Command, Debug, Parser, Runnable)]
 pub enum {{command_type}} {
     /// The `start` subcommand
     Start(StartCmd),
 }
 
 /// Entry point for the application. It needs to be a struct to allow using subcommands!
-#[derive(Command, Debug, Clap)]
+#[derive(Command, Debug, Parser)]
 #[clap(author, about, version)]
 pub struct EntryPoint {
     #[clap(subcommand)]

--- a/cli/template/src/commands/start.rs.hbs
+++ b/cli/template/src/commands/start.rs.hbs
@@ -5,16 +5,17 @@
 use crate::prelude::*;
 
 use crate::config::{{~config_type~}};
-use abscissa_core::{config, Clap, Command, FrameworkError, Runnable};
+use abscissa_core::{config, Command, FrameworkError, Runnable};
+use clap::Parser;
 
 /// `start` subcommand
 ///
-/// The `Clap` proc macro generates an option parser based on the struct
-/// definition, and is defined in the `gumdrop` crate. See their documentation
+/// The `Parser` proc macro generates an option parser based on the struct
+/// definition, and is defined in the `clap` crate. See their documentation
 /// for a more comprehensive example:
 ///
 /// <https://docs.rs/clap/>
-#[derive(Command, Debug, Clap)]
+#[derive(Command, Debug, Parser)]
 pub struct StartCmd {
     /// To whom are we saying hello?
     recipient: Vec<String>,

--- a/cli/template/src/commands/subcommand.rs.hbs
+++ b/cli/template/src/commands/subcommand.rs.hbs
@@ -1,15 +1,16 @@
 //! `{{~name_lower~}}` subcommand
 
-use abscissa_core::{Command, Clap, Runnable};
+use abscissa_core::{Command, Runnable};
+use clap::Parser;
 
 /// `{{~name_lower~}}` subcommand
 ///
-/// The `Clap` proc macro generates an option parser based on the struct
+/// The `Parser` proc macro generates an option parser based on the struct
 /// definition, and is defined in the `clap` crate. See their documentation
 /// for a more comprehensive example:
 ///
 /// <https://docs.rs/clap/>
-#[derive(Command, Debug, Clap)]
+#[derive(Command, Debug, Parser)]
 pub struct {{name_capital}} {
     // /// Option foobar. Doc comments are the help description
     // #[clap(short)]

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -23,8 +23,7 @@ backtrace = "0.3"
 canonical-path = "2"
 color-eyre = { version = "0.5", optional = true, default-features = false }
 fs-err = "2"
-clap = { version = "=3.0.0-beta.5", optional = true }
-clap_derive = { version = "=3.0.0-beta.5", optional = true }
+clap = { version = "3", optional = true, features = ["derive"] }
 once_cell = "1.4"
 regex = { version = "1", optional = true }
 secrecy = { version = "0.8", optional = true, features = ["serde"] }

--- a/core/src/application.rs
+++ b/core/src/application.rs
@@ -49,7 +49,7 @@ pub trait Application: Default + Sized + 'static {
         I: IntoIterator<Item = String>,
     {
         // Parse command line options
-        let command = Self::Cmd::from_args(args);
+        let command = Self::Cmd::parse_args(args);
 
         // Initialize application
         let mut app = Self::default();

--- a/core/src/command.rs
+++ b/core/src/command.rs
@@ -3,14 +3,15 @@
 #[doc(hidden)]
 pub use abscissa_derive::Command;
 
-use crate::{runnable::Runnable, terminal, Clap};
-use std::fmt::Debug;
+use crate::{runnable::Runnable, terminal};
+use clap::Parser;
+use std::{env, fmt::Debug};
 use termcolor::ColorChoice;
 
 /// Subcommand of an application: derives or otherwise implements the `Options`
 /// trait, but also has a `run()` method which can be used to invoke the given
 /// (sub)command.
-pub trait Command: Debug + Clap + Runnable {
+pub trait Command: Debug + Parser + Runnable {
     /// Name of this program as a string
     fn name() -> &'static str;
 
@@ -21,27 +22,27 @@ pub trait Command: Debug + Clap + Runnable {
     fn authors() -> &'static str;
 
     /// Parse command-line arguments from a string iterator
-    fn from_args<A: IntoIterator<Item = String>>(into_args: A) -> Self {
+    fn parse_args<A: IntoIterator<Item = String>>(into_args: A) -> Self {
         let args: Vec<_> = into_args.into_iter().collect();
 
-        Clap::try_parse_from(args.as_slice()).unwrap_or_else(|err| {
+        Parser::try_parse_from(args.as_slice()).unwrap_or_else(|err| {
             terminal::init(ColorChoice::Auto);
             err.exit()
         })
     }
 
     /// Parse command-line arguments from the environment
-    fn from_env_args() -> Self {
-        let args = ::std::env::args();
-        Self::from_args(args)
+    fn parse_env_args() -> Self {
+        Self::parse_args(env::args())
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use crate::{Clap, Command, Runnable};
+    use crate::{Command, Runnable};
+    use clap::Parser;
 
-    #[derive(Command, Debug, Clap)]
+    #[derive(Command, Debug, Parser)]
     pub struct DummyCommand {}
 
     impl Runnable for DummyCommand {

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -135,11 +135,6 @@ pub mod thread;
 #[cfg(feature = "trace")]
 pub mod trace;
 
-// Proc macros
-
-#[cfg(feature = "options")]
-pub use clap::Parser as Clap;
-
 // Re-exports
 
 pub use crate::{
@@ -163,6 +158,8 @@ pub use crate::{command::Command, path::StandardPaths};
 
 // Re-exported modules/types from third-party crates
 
+#[cfg(feature = "options")]
+pub use clap;
 pub use fs_err as fs;
 #[cfg(feature = "secrets")]
 pub use secrecy as secret;

--- a/core/tests/example_app/mod.rs
+++ b/core/tests/example_app/mod.rs
@@ -1,8 +1,8 @@
 //! Example application used for testing purposes
 
 use abscissa_core::{
-    application, config, Application, Clap, Command, Configurable, FrameworkError, Runnable,
-    StandardPaths,
+    application, clap::Parser, config, Application, Command, Configurable, FrameworkError,
+    Runnable, StandardPaths,
 };
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
@@ -10,7 +10,7 @@ use std::path::PathBuf;
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct ExampleConfig {}
 
-#[derive(Command, Debug, Clap)]
+#[derive(Command, Debug, Parser)]
 pub struct ExampleCommand {}
 
 impl Configurable<ExampleConfig> for ExampleCommand {


### PR DESCRIPTION
The final release of `clap` v3 is out.

This commit updates to it, and attempts to do things a bit more idiomatically in regard to the upstream changes.

Namely, the re-exports have changed so only the `clap` crate itself is re-exported, and the `clap::Parser` macro is used directly rather than re-exported under the old `Clap` name.