### PR TITLE
Change `clap` bounds for `Command` from `Parser` to `FromArgMatches`

### DIFF
--- a/core/src/application.rs
+++ b/core/src/application.rs
@@ -34,7 +34,7 @@ use std::{env, path::Path, process, vec};
 #[allow(unused_variables)]
 pub trait Application: Default + Sized + 'static {
     /// Application (sub)command which serves as the main entry point.
-    type Cmd: Command + Configurable<Self::Cfg>;
+    type Cmd: Command + Configurable<Self::Cfg> + clap::Parser;
 
     /// Configuration type used by this application.
     type Cfg: Config;


### PR DESCRIPTION
Clap has a separate `Subcommand` trait which is used instead of `Parser` on enums which represent subcommands.

For that reason `Command` can't directly bound on `Parser` and still be usable for subcommand enums.

Instead this commit changes `Command` to bound on the more general `clap::FromArgMatches` trait and moves the `clap::Parser` bound to the relevant methods for parsing toplevel arguments such as `parse_args` and `parse_env_args`.