### PR TITLE
Add "impl bridges" to `Component` derive macro

### DIFF
--- a/core/tests/component.rs
+++ b/core/tests/component.rs
@@ -4,7 +4,7 @@ mod example_app;
 
 use self::example_app::{ExampleApp, ExampleConfig};
 use abscissa_core::{
-    component, Application, Component, FrameworkError, FrameworkErrorKind::ComponentError, Shutdown,
+    component, Component, FrameworkError, FrameworkErrorKind::ComponentError, Shutdown,
 };
 use std::sync::atomic::{AtomicBool, Ordering};
 
@@ -33,14 +33,14 @@ impl FoobarComponent {
 
 /// Example component #2
 #[derive(Component, Debug, Default)]
-#[component(after_config, before_shutdown)]
+#[component(application = "ExampleApp", after_config, before_shutdown)]
 pub struct BazComponent {
     pub after_config_run: bool,
     pub before_shutdown_run: AtomicBool,
 }
 
 impl BazComponent {
-    fn after_config<A: Application>(&mut self, _config: &A::Cfg) -> Result<(), FrameworkError> {
+    fn after_config(&mut self, _config: &ExampleConfig) -> Result<(), FrameworkError> {
         self.after_config_run = true;
         Ok(())
     }

--- a/core/tests/component.rs
+++ b/core/tests/component.rs
@@ -53,6 +53,7 @@ impl BazComponent {
 
 /// Example component #3
 #[derive(Component, Debug, Default)]
+#[component(application = "self::example_app::ExampleApp")]
 #[component(inject = "init_foobar(component::FoobarComponent)")]
 #[component(inject = "init_baz(component::BazComponent)")]
 pub struct QuuxComponent {


### PR DESCRIPTION
Fixes #332.

This adds support for additional meta items to the `#[component]` attribute to indicate that the `Component` derive macro should bridge method invocations from the trait `impl` to an implementing type's own inherent `impl`. I updated `core/tests/component` to demonstrate and exercise an example of this:

https://github.com/iqlusioninc/abscissa/blob/840b980dcb96a11daeb27a6f70bcc44fd136c3a3/core/tests/component.rs#L34-L52

As demonstrated above, `after_config` and `before_shutdown` in `#[component]` each enable bridging from their respectively named methods on `Component` to equivalently-named methods in `BazComponent`'s inherent `impl`.