### PR TITLE
Fix `RUST_LOG` support

### DIFF
--- a/core/src/trace/config.rs
+++ b/core/src/trace/config.rs
@@ -18,9 +18,9 @@ impl Default for Config {
         match std::env::var("RUST_LOG") {
             Ok(val) => {
                 if val.is_empty() {
-                    val.into()
-                } else {
                     "info".to_owned().into()
+                } else {
+                    val.into()
                 }
             }
             Err(_) => "info".to_owned().into(),


### PR DESCRIPTION
The current `RUST_LOG` support is incorrectly disregarding the value of the environment variable and always using `"info"` as the filter value, except when the environment variable is empty. It seems like it was an accidental transposition of `if`/`else` branches, as reversing these appears to fix the issue.
