### PR TITLE
fix docs so they refer to start subcommand instead of hello

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ noteworthy:
 
 - `src/application.rs`: Abscissa application type for your app
 - `src/commands*`: application entrypoint and subcommands. Make sure to
-  check out the `hello.rs` example of how to make a subcommand.
+  check out the `start.rs` example of how to make a subcommand.
 - `src/config.rs`: application configuration
 - `src/error.rs`: error types
 
@@ -94,11 +94,11 @@ Abscissa applications are implemented as Rust libraries, but have a
 can run the following within your newly generated application:
 
 ```text
-$ cargo run -- hello world
+$ cargo run -- start world
 ```
 
-This will invoke the `hello` subcommand of your application (you'll
-probably want to rename that in a real app) which will print the following:
+This will invoke the `start` subcommand of your application (you
+might want to rename that in your app) which will print the following:
 
 ```text
 Hello, world!


### PR DESCRIPTION
Hi,

I stumbled across the docs referring to the `hello` subcommand, when in the current version the default is the `start` subcommand. I went ahead and fixed the `README.md`.

I was unsure whether to change `config.rs.hbs`, as well, and now I am unsure about all of it. The `start` command actually *does just say "hello"*, so maybe, instead the command should be renamed to `hello` again?

Either way, this PR makes the docs match the actual command that can be run, so it should hopefully be an improvement.

Thanks for building this! 
Cheers,
R

PS: I've read the contributing guidelines. I don't think it'd be appropriate to be listed under authors for this trivial change. Let me know if it's absolutely vital. In any case, I license my "contribution" under the terms of the Apache License, Version 2.0.