### PR TITLE
Fix logo URLs and MSRV documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ or network/web services), aiming to provide a large number of features with a
 - [cargo-audit]: audit Cargo projects for security vulnerabilities
 - [cargo-rpm]: build RPMs out of Cargo projects
 - [cosmon]: observability tool for Tendermint applications
-- [ibc-rs](https://github.com/informalsystems/ibc-rs): Rust implementation of Interblockchain Communication (IBC) modules and relayer
+- [ibc-rs]: Rust implementation of Interblockchain Communication (IBC) modules and relayer
 - [OpenLibra]: open platform for financial inclusion. Not run by Facebook.
 - [Synchronicity]: distributed build system providing BFT proofs-of-reproducibility
 - [Tendermint KMS]: key management system for Tendermint applications
@@ -61,7 +61,7 @@ Abscissa presently consists of three crates:
 
 ## Minimum Supported Rust Version
 
-Requires Rust **1.56** or newer.
+Requires Rust **1.60** or newer.
 
 ## Installation
 
@@ -211,14 +211,14 @@ read the [CONTRIBUTING.md] and [CODE_OF_CONDUCT.md] files first.
 
 [//]: # (badges)
 
-[logo]: https://www.iqlusion.io/img/github/iqlusioninc/abscissa/abscissa.svg
+[logo]: https://raw.githubusercontent.com/iqlusioninc/abscissa/main/img/abscissa.svg
 [crate-image]: https://img.shields.io/crates/v/abscissa_core.svg
 [crate-link]: https://crates.io/crates/abscissa_core
 [docs-image]: https://docs.rs/abscissa_core/badge.svg
 [docs-link]: https://docs.rs/abscissa_core/
 [license-image]: https://img.shields.io/badge/license-Apache2.0-blue.svg
 [license-link]: https://github.com/iqlusioninc/abscissa/blob/main/LICENSE
-[rustc-image]: https://img.shields.io/badge/rustc-1.56+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.60+-blue.svg
 [safety-image]: https://img.shields.io/badge/unsafe-forbidden-success.svg
 [safety-link]: https://github.com/rust-secure-code/safety-dance/
 [build-image]: https://github.com/iqlusioninc/abscissa/workflows/cli/badge.svg?branch=main&event=push
@@ -245,10 +245,11 @@ read the [CONTRIBUTING.md] and [CODE_OF_CONDUCT.md] files first.
 [//]: # (projects using abscissa)
 
 [Tendermint KMS]: https://github.com/tendermint/kms
-[Canister]:  https://github.com/iqlusioninc/canister
+[Canister]: https://github.com/iqlusioninc/canister
 [cargo-audit]: https://github.com/rustsec/cargo-audit
 [cargo-rpm]: https://github.com/rustrpm/cargo-rpm
 [cosmon]: https://github.com/iqlusioninc/cosmon
+[ibc-rs]: https://github.com/informalsystems/ibc-rs
 [OpenLibra]: https://github.com/open-libra/cli
 [Synchronicity]: https://github.com/iqlusioninc/synchronicity
 [Zebra]: https://github.com/ZcashFoundation/zebra

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -14,7 +14,7 @@ readme       = "../README.md"
 categories   = ["command-line-interface", "config", "rust-patterns"]
 keywords     = ["abscissa", "cli", "application", "framework", "service"]
 edition      = "2021"
-rust-version = "1.56"
+rust-version = "1.60"
 
 [dependencies]
 abscissa_core = { version = "0.6", path = "../core" }

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -1,5 +1,7 @@
 #![doc = include_str!("../../README.md")]
-#![doc(html_logo_url = "https://www.iqlusion.io/img/github/iqlusioninc/abscissa/abscissa-sq.svg")]
+#![doc(
+    html_logo_url = "https://raw.githubusercontent.com/iqlusioninc/abscissa/main/img/abscissa-sq.svg"
+)]
 #![forbid(unsafe_code)]
 #![warn(rust_2018_idioms, unused_lifetimes, unused_qualifications)]
 

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -14,7 +14,7 @@ readme       = "../README.md"
 categories   = ["command-line-interface", "config", "rust-patterns"]
 keywords     = ["abscissa", "cli", "application", "framework", "service"]
 edition      = "2021"
-rust-version = "1.56"
+rust-version = "1.60"
 
 [dependencies]
 abscissa_derive = { version = "0.6", path = "../derive" }

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -1,5 +1,7 @@
 #![doc = include_str!("../../README.md")]
-#![doc(html_logo_url = "https://www.iqlusion.io/img/github/iqlusioninc/abscissa/abscissa-sq.svg")]
+#![doc(
+    html_logo_url = "https://raw.githubusercontent.com/iqlusioninc/abscissa/main/img/abscissa-sq.svg"
+)]
 #![forbid(unsafe_code)]
 #![warn(
     missing_docs,

--- a/derive/Cargo.toml
+++ b/derive/Cargo.toml
@@ -8,7 +8,7 @@ homepage     = "https://github.com/iqlusioninc/abscissa"
 repository   = "https://github.com/iqlusioninc/abscissa/tree/main/abscissa_derive"
 readme       = "README.md"
 edition      = "2021"
-rust-version = "1.56"
+rust-version = "1.60"
 
 [lib]
 proc-macro = true

--- a/derive/README.md
+++ b/derive/README.md
@@ -1,4 +1,4 @@
-![Abscissa](https://www.iqlusion.io/img/github/iqlusioninc/abscissa/abscissa.svg)
+![Abscissa](https://raw.githubusercontent.com/iqlusioninc/abscissa/main/img/abscissa.svg)
 
 # abscissa_derive: custom derive macros for Abscissa
 

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -1,5 +1,7 @@
 #![doc = include_str!("../README.md")]
-#![doc(html_logo_url = "https://www.iqlusion.io/img/github/iqlusioninc/abscissa/abscissa-sq.svg")]
+#![doc(
+    html_logo_url = "https://raw.githubusercontent.com/iqlusioninc/abscissa/main/img/abscissa-sq.svg"
+)]
 #![forbid(unsafe_code)]
 #![warn(rust_2018_idioms, unused_lifetimes, unused_qualifications)]
 

--- a/tokio/Cargo.toml
+++ b/tokio/Cargo.toml
@@ -8,7 +8,7 @@ homepage     = "https://github.com/iqlusioninc/abscissa"
 repository   = "https://github.com/iqlusioninc/abscissa/tree/main/tokio"
 readme       = "README.md"
 edition      = "2021"
-rust-version = "1.56"
+rust-version = "1.60"
 
 [dependencies]
 abscissa_core = { version = "0.6", path = "../core" }

--- a/tokio/README.md
+++ b/tokio/README.md
@@ -1,4 +1,4 @@
-![Abscissa](https://www.iqlusion.io/img/github/iqlusioninc/abscissa/abscissa.svg)
+![Abscissa](https://raw.githubusercontent.com/iqlusioninc/abscissa/main/img/abscissa.svg)
 
 # abscissa_tokio: Tokio component for Abscissa
 

--- a/tokio/src/lib.rs
+++ b/tokio/src/lib.rs
@@ -87,7 +87,9 @@
 //! [`abscissa_tokio::run`]: https://docs.rs/abscissa_tokio/latest/abscissa_tokio/fn.run.html
 
 #![cfg_attr(docsrs, feature(doc_cfg))]
-#![doc(html_logo_url = "https://www.iqlusion.io/img/github/iqlusioninc/abscissa/abscissa-sq.svg")]
+#![doc(
+    html_logo_url = "https://raw.githubusercontent.com/iqlusioninc/abscissa/main/img/abscissa-sq.svg"
+)]
 #![forbid(unsafe_code)]
 #![warn(rust_2018_idioms, unused_lifetimes, unused_qualifications)]
 


### PR DESCRIPTION
- Logos were 404ing; source them from GitHub
- Bump all MSRV docs and configs to 1.60 to reflect true MSRV