### PR TITLE
Add `rustic` to Readme as a project using abscissa

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ or network/web services), aiming to provide a large number of features with a
 - [cosmon]: observability tool for Tendermint applications
 - [ibc-rs]: Rust implementation of Interblockchain Communication (IBC) modules and relayer
 - [OpenLibra]: open platform for financial inclusion. Not run by Facebook.
-- [rustic]: fast, encrypted, deduplicated backups
+- [rustic]: fast, encrypted, and deduplicated backups
 - [Synchronicity]: distributed build system providing BFT proofs-of-reproducibility
 - [Tendermint KMS]: key management system for Tendermint applications
 - [Zebra]: Rust implementation of a Zcash node

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ or network/web services), aiming to provide a large number of features with a
 - [cosmon]: observability tool for Tendermint applications
 - [ibc-rs]: Rust implementation of Interblockchain Communication (IBC) modules and relayer
 - [OpenLibra]: open platform for financial inclusion. Not run by Facebook.
+- [rustic]: fast, encrypted, deduplicated backups
 - [Synchronicity]: distributed build system providing BFT proofs-of-reproducibility
 - [Tendermint KMS]: key management system for Tendermint applications
 - [Zebra]: Rust implementation of a Zcash node
@@ -251,6 +252,7 @@ read the [CONTRIBUTING.md] and [CODE_OF_CONDUCT.md] files first.
 [cosmon]: https://github.com/iqlusioninc/cosmon
 [ibc-rs]: https://github.com/informalsystems/ibc-rs
 [OpenLibra]: https://github.com/open-libra/cli
+[rustic]: https://github.com/rustic-rs/rustic
 [Synchronicity]: https://github.com/iqlusioninc/synchronicity
 [Zebra]: https://github.com/ZcashFoundation/zebra
 [Zerostash]: https://github.com/rsdy/zerostash


### PR DESCRIPTION
Refactored `rustic` to use abscissa in https://github.com/rustic-rs/rustic/pull/617, this PR adds `rustic` to the list of projects.