### PR TITLE
Remove OpenLibra, update Tendermind KMS repository link, and move cargo-rpm to `Archived` subheading

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,8 +49,6 @@ or network/web services), aiming to provide a large number of features with a
 - [Zebra]: Rust implementation of a Zcash node
 - [Zerostash]: Encrypted and deduplicated backups
 
-### Archived
-- [cargo-rpm]: build RPMs out of Cargo projects
 
 ## Crate Structure
 

--- a/README.md
+++ b/README.md
@@ -41,15 +41,16 @@ or network/web services), aiming to provide a large number of features with a
 
 - [Canister]: deployment utility for "distroless" containers/microVMs
 - [cargo-audit]: audit Cargo projects for security vulnerabilities
-- [cargo-rpm]: build RPMs out of Cargo projects
 - [cosmon]: observability tool for Tendermint applications
 - [ibc-rs]: Rust implementation of Interblockchain Communication (IBC) modules and relayer
-- [OpenLibra]: open platform for financial inclusion. Not run by Facebook.
 - [rustic]: fast, encrypted, and deduplicated backups
 - [Synchronicity]: distributed build system providing BFT proofs-of-reproducibility
-- [Tendermint KMS]: key management system for Tendermint applications
 - [Zebra]: Rust implementation of a Zcash node
 - [Zerostash]: Encrypted and deduplicated backups
+
+### Archived
+- [cargo-rpm]: build RPMs out of Cargo projects
+- [Tendermint KMS]: key management system for Tendermint applications
 
 ## Crate Structure
 

--- a/README.md
+++ b/README.md
@@ -247,7 +247,6 @@ read the [CONTRIBUTING.md] and [CODE_OF_CONDUCT.md] files first.
 [Tendermint KMS]: https://github.com/iqlusioninc/tmkms
 [Canister]: https://github.com/iqlusioninc/canister
 [cargo-audit]: https://github.com/rustsec/cargo-audit
-[cargo-rpm]: https://github.com/rustrpm/cargo-rpm
 [cosmon]: https://github.com/iqlusioninc/cosmon
 [ibc-rs]: https://github.com/informalsystems/ibc-rs
 [OpenLibra]: https://github.com/open-libra/cli

--- a/README.md
+++ b/README.md
@@ -45,12 +45,12 @@ or network/web services), aiming to provide a large number of features with a
 - [ibc-rs]: Rust implementation of Interblockchain Communication (IBC) modules and relayer
 - [rustic]: fast, encrypted, and deduplicated backups
 - [Synchronicity]: distributed build system providing BFT proofs-of-reproducibility
+- [Tendermint KMS]: key management system for Tendermint applications
 - [Zebra]: Rust implementation of a Zcash node
 - [Zerostash]: Encrypted and deduplicated backups
 
 ### Archived
 - [cargo-rpm]: build RPMs out of Cargo projects
-- [Tendermint KMS]: key management system for Tendermint applications
 
 ## Crate Structure
 
@@ -246,7 +246,7 @@ read the [CONTRIBUTING.md] and [CODE_OF_CONDUCT.md] files first.
 
 [//]: # (projects using abscissa)
 
-[Tendermint KMS]: https://github.com/tendermint/kms
+[Tendermint KMS]: https://github.com/iqlusioninc/tmkms
 [Canister]: https://github.com/iqlusioninc/canister
 [cargo-audit]: https://github.com/rustsec/cargo-audit
 [cargo-rpm]: https://github.com/rustrpm/cargo-rpm

--- a/README.md
+++ b/README.md
@@ -249,7 +249,6 @@ read the [CONTRIBUTING.md] and [CODE_OF_CONDUCT.md] files first.
 [cargo-audit]: https://github.com/rustsec/cargo-audit
 [cosmon]: https://github.com/iqlusioninc/cosmon
 [ibc-rs]: https://github.com/informalsystems/ibc-rs
-[OpenLibra]: https://github.com/open-libra/cli
 [rustic]: https://github.com/rustic-rs/rustic
 [Synchronicity]: https://github.com/iqlusioninc/synchronicity
 [Zebra]: https://github.com/ZcashFoundation/zebra


### PR DESCRIPTION
Follow up of https://github.com/iqlusioninc/abscissa/pull/848#issuecomment-1599633363