### PR TITLE
Gate features that depend on default

### DIFF
--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -30,7 +30,7 @@ pub mod terminal;
 
 #[cfg(feature = "application")]
 pub mod application;
-#[cfg(feature = "options")]
+#[cfg(all(feature = "default", feature = "options"))]
 pub mod command;
 #[cfg(feature = "application")]
 pub mod component;
@@ -66,7 +66,7 @@ pub use crate::{
 #[cfg(feature = "config")]
 pub use crate::config::{Config, Configurable};
 
-#[cfg(feature = "options")]
+#[cfg(all(feature = "default", feature = "options"))]
 pub use crate::{command::Command, path::StandardPaths};
 
 // Re-exported modules/types from third-party crates

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -34,7 +34,7 @@ pub mod application;
 pub mod command;
 #[cfg(feature = "application")]
 pub mod component;
-#[cfg(feature = "config")]
+#[cfg(all(feature = "default", feature = "config"))]
 pub mod config;
 pub mod path;
 #[cfg(feature = "application")]
@@ -63,7 +63,7 @@ pub use crate::{
     shutdown::Shutdown,
 };
 
-#[cfg(feature = "config")]
+#[cfg(all(feature = "default", feature = "config"))]
 pub use crate::config::{Config, Configurable};
 
 #[cfg(all(feature = "default", feature = "options"))]

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -28,19 +28,19 @@ pub mod terminal;
 
 // Other modules
 
-#[cfg(feature = "application")]
+#[cfg(all(feature = "default", feature = "application"))]
 pub mod application;
 #[cfg(all(feature = "default", feature = "options"))]
 pub mod command;
-#[cfg(feature = "application")]
+#[cfg(all(feature = "default", feature = "application"))]
 pub mod component;
 #[cfg(all(feature = "default", feature = "config"))]
 pub mod config;
 pub mod path;
-#[cfg(feature = "application")]
+#[cfg(all(feature = "default", feature = "application"))]
 pub mod prelude;
 mod runnable;
-#[cfg(feature = "application")]
+#[cfg(all(feature = "default", feature = "application"))]
 mod shutdown;
 #[cfg(all(feature = "default", feature = "testing"))]
 pub mod testing;
@@ -56,7 +56,7 @@ pub use crate::{
 };
 pub use std::collections::{btree_map as map, btree_set as set, BTreeMap as Map};
 
-#[cfg(feature = "application")]
+#[cfg(all(feature = "default", feature = "application"))]
 pub use crate::{
     application::{boot, Application},
     component::Component,
@@ -78,5 +78,5 @@ pub use fs_err as fs;
 pub use secrecy as secret;
 #[cfg(feature = "secrets")]
 pub use secrecy::Secret;
-#[cfg(feature = "application")]
+#[cfg(all(feature = "default", feature = "application"))]
 pub use semver::Version;

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -42,7 +42,7 @@ pub mod prelude;
 mod runnable;
 #[cfg(feature = "application")]
 mod shutdown;
-#[cfg(feature = "testing")]
+#[cfg(all(feature = "default", feature = "testing"))]
 pub mod testing;
 pub mod thread;
 #[cfg(feature = "trace")]

--- a/core/src/terminal.rs
+++ b/core/src/terminal.rs
@@ -1,6 +1,6 @@
 //! Terminal handling (TTY interactions, colors, etc)
 
-#[cfg(feature = "application")]
+#[cfg(all(feature = "default", feature = "application"))]
 pub mod component;
 #[macro_use]
 pub mod status;

--- a/core/src/trace.rs
+++ b/core/src/trace.rs
@@ -1,9 +1,9 @@
 //! Tracing subsystem
 
-#[cfg(feature = "application")]
+#[cfg(all(feature = "default", feature = "application"))]
 pub mod component;
 mod config;
 
-#[cfg(feature = "application")]
+#[cfg(all(feature = "default", feature = "application"))]
 pub use self::component::Tracing;
 pub use self::config::Config;

--- a/core/tests/component.rs
+++ b/core/tests/component.rs
@@ -1,5 +1,5 @@
 //! Tests for Abscissa's component functionality
-
+#![cfg(feature = "default")]
 mod example_app;
 
 use self::example_app::{ExampleApp, ExampleConfig};

--- a/core/tests/example_app/mod.rs
+++ b/core/tests/example_app/mod.rs
@@ -1,5 +1,5 @@
 //! Example application used for testing purposes
-
+#![cfg(feature = "default")]
 use abscissa_core::{
     application, clap::Parser, config, Application, Command, Configurable, FrameworkError,
     Runnable, StandardPaths,


### PR DESCRIPTION
Some of the features of -core didn't compile out of the box.

Ref: https://salsa.debian.org/rust-team/debcargo-conf/-/tree/master/src/abscissa-core/debian/patches