### PR TITLE
fix: uses default info if RUST_LOG is not set

### DIFF
--- a/core/src/trace/config.rs
+++ b/core/src/trace/config.rs
@@ -15,16 +15,9 @@ impl Config {
 
 impl Default for Config {
     fn default() -> Self {
-        match std::env::var("RUST_LOG") {
-            Ok(val) => {
-                if val.is_empty() {
-                    val.into()
-                } else {
-                    "info".to_owned().into()
-                }
-            }
-            Err(_) => "info".to_owned().into(),
-        }
+        std::env::var("RUST_LOG")
+            .unwrap_or("info".to_owned())
+            .into()
     }
 }
 


### PR DESCRIPTION
Closes https://github.com/iqlusioninc/abscissa/issues/862