### PR TITLE
feat: shutdown with exit code

### DIFF
--- a/core/src/application.rs
+++ b/core/src/application.rs
@@ -167,6 +167,17 @@ pub trait Application: Default + Sized + 'static {
 
         process::exit(0);
     }
+
+    /// Shut down this application gracefully, exiting with user-defined exit code.
+    fn shutdown_with_exitcode(&self, shutdown: Shutdown, exit_code: i32) -> ! {
+        let components = self.state().components();
+
+        if let Err(e) = components.shutdown(self, shutdown) {
+            fatal_error(self, &e)
+        }
+
+        process::exit(exit_code);
+    }
 }
 
 /// Boot the given application, parsing subcommand and options from


### PR DESCRIPTION
Just as an idea, which would add a new method to the trait with a default implementation (should be non-breaking this way, I assume?):

Closes https://github.com/iqlusioninc/abscissa/issues/857

