### PR TITLE
v0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.8.0] (2024-10-15)
+### Added
+- `Application::boot_with_args` ([#805])
+- Shutdown with exit code ([#865])
+
+### Changed
+- Use Rust 2021 edition in `abscissa new` ([#856])
+- MSRV 1.74 ([#866])
+- Bump `tracing-log` to v0.2 ([#878])
+- Bump `toml` to 0.8 ([#906])
+- Bump `secrecy` to v0.10 ([#928])
+
+### Fixed
+- Uses default info if `RUST_LOG` is not set ([#863])
+
 ## [0.7.0] (2022-12-14)
 ### Changed
 - Update `clap` to v4; MSRV 1.60 ([#779])
@@ -547,6 +562,16 @@ impl std::error::Error for Error {
 ## 0.0.1 (2018-08-25)
 
 - Initial release
+
+[0.8.0]: https://github.com/iqlusioninc/abscissa/pull/930
+[#805]: https://github.com/iqlusioninc/abscissa/pull/805
+[#856]: https://github.com/iqlusioninc/abscissa/pull/856
+[#863]: https://github.com/iqlusioninc/abscissa/pull/863
+[#865]: https://github.com/iqlusioninc/abscissa/pull/865
+[#866]: https://github.com/iqlusioninc/abscissa/pull/866
+[#878]: https://github.com/iqlusioninc/abscissa/pull/878
+[#906]: https://github.com/iqlusioninc/abscissa/pull/906
+[#928]: https://github.com/iqlusioninc/abscissa/pull/928
 
 [0.7.0]: https://github.com/iqlusioninc/abscissa/pull/793
 [#779]: https://github.com/iqlusioninc/abscissa/pull/779

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 3
 
 [[package]]
 name = "abscissa"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "abscissa_core",
  "clap",
@@ -16,7 +16,7 @@ dependencies = [
 
 [[package]]
 name = "abscissa_core"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "abscissa_derive",
  "arc-swap",
@@ -40,7 +40,7 @@ dependencies = [
 
 [[package]]
 name = "abscissa_derive"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "ident_case",
  "proc-macro2",
@@ -51,7 +51,7 @@ dependencies = [
 
 [[package]]
 name = "abscissa_tokio"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "abscissa_core",
  "actix-rt",

--- a/README.md
+++ b/README.md
@@ -6,7 +6,6 @@
 ![MSRV][rustc-image]
 [![Safety Dance][safety-image]][safety-link]
 [![Build Status][build-image]][build-link]
-[![Gitter Chat][gitter-image]][gitter-link]
 
 Abscissa is a microframework for building Rust applications (either CLI tools
 or network/web services), aiming to provide a large number of features with a
@@ -61,7 +60,7 @@ Abscissa presently consists of three crates:
 
 ## Minimum Supported Rust Version
 
-Requires Rust **1.60** or newer.
+Requires Rust **1.74** or newer.
 
 ## Installation
 
@@ -190,7 +189,7 @@ For more information, please see [CODE_OF_CONDUCT.md].
 The **abscissa** crate is distributed under the terms of the
 Apache License (Version 2.0).
 
-Copyright © 2018-2022 iqlusion
+Copyright © 2018-2024 iqlusion
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -212,19 +211,17 @@ read the [CONTRIBUTING.md] and [CODE_OF_CONDUCT.md] files first.
 [//]: # (badges)
 
 [logo]: https://raw.githubusercontent.com/iqlusioninc/abscissa/main/img/abscissa.svg
-[crate-image]: https://img.shields.io/crates/v/abscissa_core.svg
+[crate-image]: https://img.shields.io/crates/v/abscissa_core.svg?logo=rust
 [crate-link]: https://crates.io/crates/abscissa_core
 [docs-image]: https://docs.rs/abscissa_core/badge.svg
 [docs-link]: https://docs.rs/abscissa_core/
 [license-image]: https://img.shields.io/badge/license-Apache2.0-blue.svg
 [license-link]: https://github.com/iqlusioninc/abscissa/blob/main/LICENSE
-[rustc-image]: https://img.shields.io/badge/rustc-1.60+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.74+-blue.svg
 [safety-image]: https://img.shields.io/badge/unsafe-forbidden-success.svg
 [safety-link]: https://github.com/rust-secure-code/safety-dance/
 [build-image]: https://github.com/iqlusioninc/abscissa/workflows/cli/badge.svg?branch=main&event=push
 [build-link]: https://github.com/iqlusioninc/abscissa/actions
-[gitter-image]: https://badges.gitter.im/iqlusioninc/community.svg
-[gitter-link]: https://gitter.im/iqlusioninc/community
 
 [//]: # (crate links)
 

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -5,7 +5,7 @@ Application microframework with support for command-line option parsing,
 configuration, error handling, logging, and terminal interactions.
 This crate contains a CLI utility for generating new applications.
 """
-version      = "0.7.0"
+version      = "0.8.0"
 license      = "Apache-2.0"
 authors      = ["Tony Arcieri <tony@iqlusion.io>"]
 homepage     = "https://github.com/iqlusioninc/abscissa/"
@@ -14,15 +14,15 @@ readme       = "../README.md"
 categories   = ["command-line-interface", "config", "rust-patterns"]
 keywords     = ["abscissa", "cli", "application", "framework", "service"]
 edition      = "2021"
-rust-version = "1.60"
+rust-version = "1.74"
 
 [dependencies]
-abscissa_core = { version = "0.7", path = "../core" }
+abscissa_core = { version = "0.8", path = "../core" }
 clap = "4"
 handlebars = "4"
 ident_case = "1"
 serde = { version = "1", features = ["serde_derive"] }
 
 [dev-dependencies]
-abscissa_core = { version = "0.7", features = ["testing"], path = "../core" }
+abscissa_core = { version = "0.8", features = ["testing"], path = "../core" }
 once_cell = "1"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -5,7 +5,7 @@ Application microframework with support for command-line option parsing,
 configuration, error handling, logging, and terminal interactions.
 This crate contains the framework's core functionality.
 """
-version      = "0.7.0"
+version      = "0.8.0"
 license      = "Apache-2.0"
 authors      = ["Tony Arcieri <tony@iqlusion.io>"]
 homepage     = "https://github.com/iqlusioninc/abscissa/"
@@ -14,10 +14,10 @@ readme       = "../README.md"
 categories   = ["command-line-interface", "config", "rust-patterns"]
 keywords     = ["abscissa", "cli", "application", "framework", "service"]
 edition      = "2021"
-rust-version = "1.60"
+rust-version = "1.74"
 
 [dependencies]
-abscissa_derive = { version = "0.7", path = "../derive" }
+abscissa_derive = { version = "0.8", path = "../derive" }
 backtrace = "0.3"
 canonical-path = "2"
 fs-err = "2"

--- a/derive/Cargo.toml
+++ b/derive/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
 name         = "abscissa_derive"
 description  = "Custom derive support for the abscissa application microframework"
-version      = "0.7.0"
+version      = "0.8.0"
 license      = "Apache-2.0"
 authors      = ["Tony Arcieri <tony@iqlusion.io>"]
 homepage     = "https://github.com/iqlusioninc/abscissa"
 repository   = "https://github.com/iqlusioninc/abscissa/tree/main/abscissa_derive"
 readme       = "README.md"
 edition      = "2021"
-rust-version = "1.60"
+rust-version = "1.74"
 
 [lib]
 proc-macro = true

--- a/derive/README.md
+++ b/derive/README.md
@@ -19,7 +19,7 @@ from Abscissa, and the proc macros will be in scope.
 The **abscissa_derive** crate is distributed under the terms of the
 Apache License (Version 2.0).
 
-Copyright © 2018-2022 iqlusion
+Copyright © 2018-2024 iqlusion
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -35,7 +35,7 @@ limitations under the License.
 
 [//]: # (badges)
 
-[crate-image]: https://img.shields.io/crates/v/abscissa_derive.svg
+[crate-image]: https://img.shields.io/crates/v/abscissa_derive.svg?logo=rust
 [crate-link]: https://crates.io/crates/abscissa_derive
 [docs-image]: https://docs.rs/abscissa_core/badge.svg
 [docs-link]: https://docs.rs/abscissa_core/

--- a/tokio/Cargo.toml
+++ b/tokio/Cargo.toml
@@ -1,17 +1,17 @@
 [package]
 name         = "abscissa_tokio"
 description  = "Support for launching Tokio runtimes within Abscissa applications"
-version      = "0.7.0"
+version      = "0.8.0"
 license      = "Apache-2.0"
 authors      = ["Tony Arcieri <tony@iqlusion.io>"]
 homepage     = "https://github.com/iqlusioninc/abscissa"
 repository   = "https://github.com/iqlusioninc/abscissa/tree/main/tokio"
 readme       = "README.md"
 edition      = "2021"
-rust-version = "1.60"
+rust-version = "1.74"
 
 [dependencies]
-abscissa_core = { version = "0.7", path = "../core" }
+abscissa_core = { version = "0.8", path = "../core" }
 tokio = { version = "1", features = ["rt-multi-thread"] }
 actix-rt = { version = "2.2", optional = true }
 

--- a/tokio/README.md
+++ b/tokio/README.md
@@ -36,7 +36,7 @@ See documentation for usage instructions.
 The **abscissa_tokio** crate is distributed under the terms of the
 Apache License (Version 2.0).
 
-Copyright © 2020 iqlusion
+Copyright © 2020-2024 iqlusion
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -52,7 +52,7 @@ limitations under the License.
 
 [//]: # (badges)
 
-[crate-image]: https://img.shields.io/crates/v/abscissa_tokio.svg
+[crate-image]: https://img.shields.io/crates/v/abscissa_tokio.svg?logo=rust
 [crate-link]: https://crates.io/crates/abscissa_tokio
 [docs-image]: https://docs.rs/abscissa_tokio/badge.svg
 [docs-link]: https://docs.rs/abscissa_tokio/


### PR DESCRIPTION
### Added
- `Application::boot_with_args` ([#805])
- Shutdown with exit code ([#865])

### Changed
- Use Rust 2021 edition in `abscissa new` ([#856])
- MSRV 1.74 ([#866])
- Bump `tracing-log` to v0.2 ([#878])
- Bump `toml` to 0.8 ([#906])
- Bump `secrecy` to v0.10 ([#928])

### Fixed
- Uses default info if `RUST_LOG` is not set ([#863])

[#805]: https://github.com/iqlusioninc/abscissa/pull/805
[#856]: https://github.com/iqlusioninc/abscissa/pull/856
[#863]: https://github.com/iqlusioninc/abscissa/pull/863
[#865]: https://github.com/iqlusioninc/abscissa/pull/865
[#866]: https://github.com/iqlusioninc/abscissa/pull/866
[#878]: https://github.com/iqlusioninc/abscissa/pull/878
[#906]: https://github.com/iqlusioninc/abscissa/pull/906
[#928]: https://github.com/iqlusioninc/abscissa/pull/928