### PR TITLE
v0.8.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.8.2] (2025-01-28)
+### Fixed
+- Print all status messages to stderr ([#959])
+- Un-`pub` some statics that don't have to be pub to fix build under `deny(warnings)` ([#960])
+- Add `allow()` for const impl pattern that causes false positives in a rustc lint in derive macros ([#960])
+
 ## [0.8.1] (2024-10-15)
 ### Fixed
 - Path to README.md for `abscissa_core` ([#932])
@@ -566,6 +572,10 @@ impl std::error::Error for Error {
 ## 0.0.1 (2018-08-25)
 
 - Initial release
+
+[0.8.2]: https://github.com/iqlusioninc/abscissa/pull/964
+[#959]: https://github.com/iqlusioninc/abscissa/pull/959
+[#960]: https://github.com/iqlusioninc/abscissa/pull/960
 
 [0.8.1]: https://github.com/iqlusioninc/abscissa/pull/933
 [#932]: https://github.com/iqlusioninc/abscissa/pull/932

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16,7 +16,7 @@ dependencies = [
 
 [[package]]
 name = "abscissa_core"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "abscissa_derive",
  "arc-swap",
@@ -40,7 +40,7 @@ dependencies = [
 
 [[package]]
 name = "abscissa_derive"
-version = "0.8.0"
+version = "0.8.2"
 dependencies = [
  "ident_case",
  "proc-macro2",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -5,7 +5,7 @@ Application microframework with support for command-line option parsing,
 configuration, error handling, logging, and terminal interactions.
 This crate contains the framework's core functionality.
 """
-version      = "0.8.1"
+version      = "0.8.2"
 license      = "Apache-2.0"
 authors      = ["Tony Arcieri <tony@iqlusion.io>"]
 homepage     = "https://github.com/iqlusioninc/abscissa/"

--- a/derive/Cargo.toml
+++ b/derive/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name         = "abscissa_derive"
 description  = "Custom derive support for the abscissa application microframework"
-version      = "0.8.0"
+version      = "0.8.2"
 license      = "Apache-2.0"
 authors      = ["Tony Arcieri <tony@iqlusion.io>"]
 homepage     = "https://github.com/iqlusioninc/abscissa"


### PR DESCRIPTION
### Fixed
- Print all status messages to stderr ([#959])
- Un-`pub` some statics that don't have to be pub to fix build under `deny(warnings)` ([#960])
- Add `allow()` for const impl pattern that causes false positives in a rustc lint in derive macros ([#960])

[#959]: https://github.com/iqlusioninc/abscissa/pull/959
[#960]: https://github.com/iqlusioninc/abscissa/pull/960